### PR TITLE
Remove redundant ID header from RFC template

### DIFF
--- a/rfcs/yyyymmdd-rfc-template.md
+++ b/rfcs/yyyymmdd-rfc-template.md
@@ -2,7 +2,6 @@
 
 | Status        | (Proposed / Accepted / Implemented / Obsolete)       |
 :-------------- |:---------------------------------------------------- |
-| **ID**        | <this will be allocated on approval>                 |
 | **Author(s)** | My Name (me@example.org), AN Other (you@example.org) |
 | **Sponsor**   | A N Expert (whomever@tensorflow.org)                 |
 | **Updated**   | YYYY-MM-DD                                           |


### PR DESCRIPTION
The ID is actually the filename of the markdown doc, so no need for ID.