### PR TITLE
RFC: Distribution Strategy - Revised API

### DIFF
--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -1,0 +1,964 @@
+# Replicator API
+
+| Status        | Proposed                                                |
+| :------------ | :------------------------------------------------------ |
+| **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, |
+:               : petebu@google.com, priyag@google.com                    :
+| **Sponsor**   | joshl@google.com                                        |
+| **Updated**   | 2018-10-16                                              |
+
+## Objective
+
+We propose to add a new API in TensorFlow for replicating computation across
+different GPUs, TPUs and multiple machines. It will be implemented as a thin
+usability API layer on top of
+[DistributionStrategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy).
+
+The Replicator API will be primarily targeted at ML researchers, who often
+require greater flexibility than is exposed by the high-level APIs (e.g.
+Estimator, Keras which are already integrated with Distribution Strategy
+directly). This would provide TF users with research-focused API that has
+already been "battle-tested" by internal Alphabet users. Replicator will be TF
+2.0 and Eager-mode ready.
+
+## Overview
+
+### Replicator
+
+Replicator will be a TensorFlow library to transparently replicate computation
+across several machines / GPUs / TPUs.
+
+Replicator's design aspirations include:
+
+*   Highly usable for the majority of researchers.
+*   User-friendly minimal API.
+*   Equal performance to manually replicated code.
+
+To use this API, the user creates a `Replicator` object with the appropriate
+distribution strategy instance. Then they build the graph / executes
+computations using Replicator primitives. They can then trivially switch their
+code to work with 1-GPU / n-GPUs / multi-worker-GPU / TPU by changing the
+distribution strategy passed to the `Replicator`.
+
+Unlike `Estimator` and `tf.Keras` APIs, Replicator:
+
+*   Allows / requires the user to write their own main training loop.
+*   Easily supports multiple inputs, outputs and optimizers in the model. One
+    can write a custom Estimator which has multiple optimizers but this would be
+    rather cumbersome.
+
+The Replicator API has been prototyped internally and refined in collaboration
+with Alphabet researchers.
+
+### Distribution Strategy
+
+[DistributionStrategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy)
+is a flexible low-level API that can be used to distribute computation across
+over machines / GPUs / TPUs. So in this sense, it has the same goals as
+Replicator.
+
+Distribution Strategy’s low level APIs are now well integrated into Estimator
+and Keras high level APIs. Users can now distribute their code written with
+Estimator and Keras APIs to GPUs/TPUs/multiple machines with typically only 2-3
+lines of code changes
+([see example usage](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/README.md)).
+
+Distribution Strategy’s low level APIs can be directly used to distribute
+training programs written with low level TensorFlow APIs (i.e. without
+Estimator/Keras). But it can be tedious and error prone as it exposes an
+extensive and flexible API. There is a skeleton of a mid-level API within
+Distribution Strategy
+([`Step`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/python/step_fn.py),
+[`Monitor`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/python/monitor.py))
+where users can write their own main-loops more easily, but this has not yet
+been developed fully or tested with real users.
+
+Hence, adding the Replicator API layer on top of Distribution Strategy APIs
+fills this gap for users who require more flexibility in their training loops.
+
+Distribution Strategy now supports a number of different strategies:
+
+*   `MirroredStrategy` for synchronous
+    ([in-graph](https://www.tensorflow.org/deploy/distributed)) training across
+    multiple devices on one or more machines.
+*   `CollectiveAllReduceStrategy` for synchronous
+    ([between-graph)](https://www.tensorflow.org/deploy/distributed) training
+    across multiple machines.
+*   `TPUStrategy` for using TPUs.
+*   `ParameterServerStrategy` for async parameter server training.
+
+## Design
+
+### Overview
+
+The basic idea of the Replicator API is that the user can write their code as if
+it was running on a single device. By adding just a few lines of Replicator
+code, the computation can then be run across multiple machines and / or devices.
+The computation that is running on each device is a [replica](#replica) of the
+user computation (assuming no [model parallelism](#model-parallelism) across
+devices).
+
+The Replicator API provides a number of primitives to facilitate communication
+across replicas. The most common use case is the aggregation of gradients for
+synchronous SGD training. Replicator natively supports this by automatically
+adding cross-replica gradient accumulation to any TensorFlow optimizer created
+within a replicator scope (see the
+[Simple Classification](#simple-classification) example below). For more
+advanced use cases (such as cross-replica batch normalisation), the API provides
+MPI-like primitives for sending and receiving tensors across replicas.
+
+The TF sub-graph generating input data is treated separately from the sub-graph
+performing the main computation (e.g. training a model). This decoupling
+provides flexibility in how input pipelines are connected to replicas. For
+example, replicas running on the same worker can be fed from the same input
+pipeline, which is often more efficient than having a separate input pipeline
+per replica.
+
+The API has been designed to work for all types of devices, including TPUs, so
+that code can be seamlessly moved between different device targets.
+
+### Concepts / Terminology
+
+#### Replica
+
+A replica is "one copy of the computation" that the user wants to replicate. You
+can think of it as "one copy of the model". In distribution strategy, this was
+formerly known as a "tower". We might also refer to this as "compute replica" or
+"model replica" in some places.
+
+When using model parallelism, a replica will span several physical devices (e.g.
+GPUs, TPU cores) and may also span multiple physical machines.
+
+#### Worker
+
+The physical machine(s) containing the physical devices (e.g. GPUs, TPUs) on
+which the replicated computation is executed. A worker may contain one or more
+replicas. Typically one worker will correspond to one host machine, but in the
+case of very large models with model parallelism, one worker may span multiple
+hosts.
+
+#### Sync vs Async replicas
+
+In synchronous training, all replicas are in sync with each other and gradients
+are aggregated across all the replicas. In fully asynchronous training, all
+replicas operate asynchronously and update the variables independently. We can
+also support a hybrid approach, where the replicas are divided into "sync
+groups" - within each sync group, each replica is in sync, but the sync groups
+are asynchronous among themselves. To support this, we later define
+"num_replicas" as the total number of replicas (sync or async) and
+"num_replicas_in_sync" as the number of replicas in one sync group.
+
+#### Input Pipeline
+
+An instance of the input pipeline (e.g. `Dataset`, `FIFOQueue`) obtained by
+calling the user's `input_fn` once. One input pipeline may be used to feed one
+or more model replicas (on one or more workers). See
+[InputReplicationMode](#inputreplicationmode).
+
+### Replicator API
+
+#### Detailed Design
+
+Here are the main ingredients of the API:
+
+*   `Replicator` class: This is the main class of the API and provides the main
+    methods to replicate the computation.
+    *   `__init__:`Creates a Replicator instance. It takes a
+        `DistributionStrategy` object which is used for (almost) all the
+        underlying operations such as replicating the computation, all-reduce
+        etc.
+    *   `scope`: A context manager that manages variable creation correctly
+        within its scope, and also sets the distribution strategy as current for
+        the current graph & thread. Variables that need to be replicated must be
+        created within `Replicator.scope`, unless they are created inside the
+        `fn` passed to `run` which automatically wraps the entire `fn` inside
+        `Replicator.scope`. Entering a `scope` twice is safe, so in general,
+        enclosing everything that is potentially distributed inside a `scope`
+        should be safe.
+    *   `run`: This method is used to replicate the computation. It takes a
+        function `fn` which specifies the computation, and an (optional)
+        `InputIterator` `inputs` to be fed into`fn`. It calls `fn` with one
+        element from the input iterator within distribution strategy `scope`.
+        Variables and optimizers for the model can be created inside or outside
+        `fn`, as long as they're created within `scope`. `run` can be called
+        multiple times with different `fn`. In graph mode, run simply creates
+        the replicated graph whereas in eager mode, it will run the actual
+        computation. It then returns the list of outputs of `fn` from each
+        replica.
+    *   `prepare_input`: This method is used to prepare the input for being
+        passed to run. It takes an `InputFn` `fn` which either returns a
+        `Dataset` or a function which returns
+        ([nests](https://www.tensorflow.org/api_docs/python/tf/contrib/framework/nest)
+        of) input tensors. It also takes an optional `InputReplicationMode`
+        `replication_mode` which specifies how, if at all, the input fn should
+        be replicated. The current options are (1) no replication, (2) replicate
+        per worker (default option), and (3) replicate per compute-replica. See
+        [InputReplicationMode](#inputreplicationmode) section for more details.
+        It returns an `InputIterator` which should be passed into `run` for
+        consumption according to the distribution strategy. `prepare_input` can
+        be called multiple times as well, potentially to get different inputs
+        being passed to different calls to `run`.
+    *   `initialize` / `finalize`: This returns ops that should be run before
+        and after running replicated computations, respectively. Typically this
+        would contain things like TPU initialize / finalize ops, and dataset
+        iterator initialize ops. In eager mode, this will instead run the
+        initialize and finalize ops directly instead of returning them.
+*   `ReplicaContext`: This is an object that is passed as the first argument to
+    `fn` when called with `run`. It contains information about the replication
+    context, such as the number of replicas, current replica id etc. It also
+    provides the methods for communication across replicas such as `all_sum`,
+    `broadcast`, etc.
+*   Input: Replicating and distributing the input correctly across replicas is
+    an important component of replicating the computation. The API provides a
+    number of input related functionality to support different use cases.
+    *   `InputReplicationMode`: The user may want to use the same input pipeline
+        for all their replicas, or have a separate input pipeline per worker or
+        per replica. This mode allows the user to specify which mode they want.
+        The knowledge of this mode helps us create the appropriate input
+        iterator. See [InputReplicationMode](#inputreplicationmode) for more
+        details.
+    *   `InputContext`: This is a context object that is passed to the user's
+        `InputFn` and contains information about the compute replicas and input
+        pipelines. The number of compute replicas (in sync training) helps
+        compute per input pipeline batch size from the desired global batch
+        size. Input pipeline information can be used to return a different
+        subset of the input in each input pipeline (for e.g. shard the input
+        pipeline, use a different input source etc).
+    *   `InputIterator`: This is a new type of iterator returned by
+        `prepare_input` which should be passed to `replicator.run`. If the user
+        chooses to implement their own input preparation, they can also simply
+        implement this API (instead of using `replicator.prepare_input`). They
+        will be responsible for any initialization for such input pipeline
+        themselves.
+
+The typical usage of this API is as follows:
+
+*   Define a replicator instance with the appropriate distribution strategy.
+*   Create the model and optimizer within the replicator scope.
+*   Define an input function which returns the input for the computation.
+    Replicate it using `replicator.prepare_input`.
+*   Define a step function which takes input as argument and does a single step
+    of computation.
+*   Replicate the step function with `replicator.run` passing it the replicated
+    input.
+
+Next, we will show the code for the API as well as sample usage examples.
+
+#### Replicator class
+
+```python
+Nest = ...  # Type supported by `tf.nest`.
+T = TypeVar("T", Nest[tf.Tensor])  # A generic `Tensor` nest.
+U = TypeVar("U", Nest[tf.Tensor])  # Another generic `Tensor` nest.
+
+InputGenerator = Callable[[], T]
+InputFn = Callable[[InputContext], Union[tf.data.Dataset, InputGenerator[T]]]
+
+class Replicator(object):
+
+  def __init__(self, distribution: DistributionStrategy):
+    """Creates a `Replicator` with the given distribution strategy."""
+
+  def initialize(self) -> List[tf.Operation]:
+    """Initialization to be performed before running any computations.
+
+    In eager mode, it performs any necessary initialization.
+    In graph mode, it creates initialization ops and returns them.
+
+    In graph mode, the returned list will include the initialization ops for any
+    `tf.data.Dataset` iterators created by preceding calls to `prepare_input`.
+
+    Returns:
+      In eager mode, returns an empty list.
+      In graph mode, returns the list of ops to execute.
+    """
+
+  def finalize(self) -> List[tf.Operation]:
+    """Finalization to be performed after the end of all computations.
+
+    In eager mode, it performs any necessary finalization.
+    In graph mode, it creates finalization ops and returns them.
+
+    Returns:
+      In eager mode, returns an empty list.
+      In graph mode, returns the list of ops to execute.
+    """
+
+  def scope(self) -> ContextManager:
+    """Returns a context for model / `Variable` creation.
+
+    Models used within `run` must be created in this scope, so that `Variable`s
+    can be correctly replicated and / or placed on the correct devices.
+
+    N.B. This context is automatically applied within `run`.
+    """
+
+  def prepare_input(
+      self,
+      fn: InputFn[T],
+      replication_mode: InputReplicationMode = InputReplicationMode.PER_WORKER,
+      prefetch_on_device: Optional[bool] = None,
+      enforce_ordering: bool = False) -> InputIterator[T]:
+    """Prepares the input data.
+
+    Depending on the input replication mode, the input function may be called one time
+    or several. We call the result of each call an “input pipeline”. Disjoint subsets of the compute
+    replicas will draw their input data from each input pipeline. See `InputReplicationMode` for
+    more details.
+
+    If `fn` returns an instance of `tf.data.Dataset`, a corresponding `tf.data.Iterator` will be
+    created. Each replica taking its input from this pipeline will execute `Iterator.get_next()`.
+    The `tf.data.Iterator`(s) can be re-initialized by calling the `reinitialize` on the returned
+    `InputIterator` object.
+
+    If `fn` returns a Python callable (e.g. `FIFOQueue.dequeue`), that callable will be executed on
+    each replica taking its input from this pipeline. `InputIterator.reinitialize` will have no effect on
+    this pipeline.
+
+    Args:
+      fn: The input function.
+        The function must take an `InputContext` as the only parameter. It must return either
+        an instance of `tf.data.Dataset` or a parameter-less Python callable that returns a
+        `Tensor` nest.
+      replication_mode: The input replication mode. Defaults to per-worker replication.
+      prefetch_on_device: Indicates whether to prefetch input data to the devices.
+        For now we use a buffer size of 1 for this prefetch.
+      enforce_ordering: Indicates whether to enforce input ordering.
+        If `True`, replicas will receive data from their respective sources
+        in replica ID order (i.e. replica 0 reads before replica 1, etc.).
+    """
+
+  @overload
+  def run(
+      self,
+      fn: Callable[[ReplicaContext], U]) -> List[U]:
+  @overload
+  def run(
+      self,
+      fn: Callable[[ReplicaContext, T], U],
+      inputs: InputIterator[T]) -> List[U]:
+    """Replicates a computation on each replica, with the given inputs.
+
+    In eager mode, executes `fn` on each replica.
+    In graph mode, builds a graph to execute `fn` on each replica.
+
+    Each replica will take a single, different input from the list of inputs
+    provided by the input iterator.
+
+    IMPORTANT: Depending on the `DistributionStrategy` being used, `fn` may be
+    called one, or several, times.
+
+    Returns:
+      A list of the outputs from each replica.
+    """
+
+  def logical_device_for_variables(self, logical_device_id: int) -> ContextManager:
+    """Returns a context to place variables on the given logical device."""
+
+  @property
+  def num_replicas(self) -> int:
+    """Returns the total number of replicas."""
+
+  @property
+  def num_replicas_in_sync(self) -> int:
+    """Returns the number of replicas training in sync."""
+```
+
+#### ReplicaContext
+
+An instance of the `ReplicaContext` is passed to the function passed to `run`.
+
+```python
+class ReplicaContext(object):
+  @property
+  def replica_id(self) -> tf.Tensor:
+    "Returns the current replica ID."""
+
+  @property
+  def num_replicas(self) -> int:
+    """Returns the total number of replicas."""
+
+  @property
+  def num_replicas_in_sync(self) -> int:
+    """Returns the number of replicas training in sync."""
+
+  def logical_device(self, logical_device_id: int) -> ContextManager:
+    """Returns a context to place ops / variables on the given logical device."""
+
+  def all_sum(self, value: T) -> T:
+    """All-sums the given `Tensor` nest across replicas.
+
+    If `all_sum` is called in any replica, it must be called in all replicas.
+    The nested structure and `Tensor` shapes must be identical in all replicas.
+
+    IMPORTANT: The ordering of communications must be identical in all replicas.
+
+    Example with two replicas:
+      Replica 0:: `value`: {'a': 1, 'b': [40,  1]}
+      Replica 1:: `value`: {'a': 3, 'b': [ 2, 98]}
+
+      Replica 0:: result: {'a': 4, 'b': [42, 99]}
+      Replica 1:: result: {'a': 4, 'b': [42, 99]}
+
+    Args:
+      value: The nested structure of `Tensor`s to all-sum.
+        The structure must be compatible with `tf.nest`.
+
+    Returns:
+       A `Tensor` nest with the summed `value`s from each replica.
+    """
+
+  def all_min(self, value: T) -> T:
+    """All-mins the given `Tensor` nest across replicas.
+
+    If `all_min` is called in any replica, it must be called in all replicas.
+    The nested structure and `Tensor` shapes must be identical in all replicas.
+
+    IMPORTANT: The ordering of communications must be identical in all replicas.
+
+    Example with two replicas:
+      Replica 0:: `value`: {'a': 1, 'b': [40,  1]}
+      Replica 1:: `value`: {'a': 3, 'b': [ 2, 98]}
+
+      Replica 0:: result: {'a': 1, 'b': [2, 1]}
+      Replica 1:: result: {'a': 1, 'b': [2, 1]}
+
+    Args:
+      value: The nested structure of `Tensor`s to all-min.
+        The structure must be compatible with `tf.nest`.
+
+    Returns:
+       A `Tensor` nest with the element-wise minimum `value`s from each replica.
+    """
+
+  def all_max(self, value: T) -> T:
+    """All-maxs the given `Tensor` nest across replicas.
+
+    If `all_max` is called in any replica, it must be called in all replicas.
+    The nested structure and `Tensor` shapes must be identical in all replicas.
+
+    IMPORTANT: The ordering of communications must be identical in all replicas.
+
+    Example with two replicas:
+      Replica 0:: `value`: {'a': 1, 'b': [40,  1]}
+      Replica 1:: `value`: {'a': 3, 'b': [ 2, 98]}
+
+      Replica 0:: result: {'a': 3, 'b': [40, 98]}
+      Replica 1:: result: {'a': 3, 'b': [40, 98]}
+
+    Args:
+      value: The nested structure of `Tensor`s to all-max.
+        The structure must be compatible with `tf.nest`.
+
+    Returns:
+       A `Tensor` nest with the element-wise maximum `value`s from each replica.
+    """
+
+  def all_gather(self, value: T) -> T:
+    """Gathers the given `Tensor` nest from all replicas.
+
+    If `all_gather` is called in any replica, it must be called in all replicas.
+    The nested structure and `Tensor` shapes must be identical in all replicas.
+
+    IMPORTANT: The ordering of communications must be identical in all replicas.
+
+    Example with two replicas:
+      Replica 0:: `value`: {'a': 1, 'b': [40,  1]}
+      Replica 1:: `value`: {'a': 3, 'b': [ 2, 98]}
+
+      Replica 0:: result: {'a': [1, 3], 'b': [[40, 1], [2, 98]]}
+      Replica 1:: result: {'a': [1, 3], 'b': [[40, 1], [2, 98]]}
+
+    Args:
+      value: The nested structure of `Tensor`s to gather across replicas.
+        The structure must be compatible with `tf.nest`.
+
+    Returns:
+       A `Tensor` nest with the `value`s from each replica. If a `Tensor` within
+       `value` has shape `dims`, the returned `Tensor` will have shape
+       `[num_replicas] + `dims`.
+    """
+
+  def broadcast(self, value: T, source_replica_id: int) -> T:
+    """Broadcasts the given `Tensor` nest from the source to all replicas.
+
+    If `broadcast` is called in any replica, it must be called in all replicas.
+    The nested structure, `Tensor` shapes, and `source_replica_id` must be
+    identical in all replicas.
+
+    IMPORTANT: The ordering of communications must be identical in all replicas.
+
+    `value` will always be evaluated on all replicas.
+
+    Example with two replicas:
+      Replica 0:: `value`: {'a': 1, 'b': [40,  1]}, `source_replica_id`: 1
+      Replica 1:: `value`: {'a': 3, 'b': [ 2, 98]}, `source_replica_id`: 1
+
+      Replica 0:: result: {'a': 3, 'b': [ 2, 98]}
+      Replica 1:: result: {'a': 3, 'b': [ 2, 98]}
+
+    Args:
+      value: The nested structure of `Tensor`s to broadcast.
+        The structure must be compatible with `tf.nest`.
+      source_replica_id: The ID of the replica from which to broadcast.
+
+    Returns:
+      A `Tensor` nest with the `value` from the source replica.
+    """
+```
+
+#### InputReplicationMode
+
+```python
+class InputReplicationMode(enum.Enum):
+  SINGLE = 0
+  PER_WORKER = 1
+  PER_REPLICA = 2
+```
+
+##### SINGLE
+
+The input function will be called once, typically on the first worker. The
+entire input pipeline ops then live on that worker. All replicas (on that and
+other workers) will dequeue from a single `Dataset` created on that worker.
+
+This mode is not supported by between-graph Distribution Strategy
+implementations.
+
+##### PER_WORKER
+
+The input function will be called on each worker independently, creating as many
+input pipelines as number of workers. Replicas will dequeue from the local
+`Dataset` on their worker. Replicator doesn't manage any state sharing between
+such separate input pipelines.
+
+##### PER_REPLICA
+
+The input function will be called for every replica, on the corresponding
+worker, thus creating as many input pipelines as number of replicas. Each
+replica will dequeue from its own `Dataset`.
+
+#### InputContext
+
+An instance of `InputContext` is passed to the input function.
+
+```python
+class InputContext(object):
+  @property
+  def num_replicas(self) -> int:
+    """Returns the total number of compute replicas."""
+
+  @property
+  def num_replicas_in_sync(self) -> int:
+    """Returns the number of compute replicas training in sync."""
+
+  @property
+  def input_pipeline_id(self) -> int:
+    """Returns the input pipeline ID.
+
+    If `replication_mode` == `SINGLE`, this is always `0`.
+    If `replication_mode` == `PER_WORKER`, this is the worker ID.
+    If `replication_mode` == `PER_REPLICA`, this is the compute replica ID.
+    """
+
+  @property
+  def num_input_pipelines(self) -> int:
+    """Returns the number of input pipelines.
+
+    If `replication_mode` == `SINGLE`, this is always `1`.
+    If `replication_mode` == `PER_WORKER`, this is the number of workers.
+    If `replication_mode` == `PER_REPLICA`, this is `num_replicas`.
+    """
+```
+
+#### InputIterator
+
+An instance of `InputIterator` is returned by `prepare_input` and can be passed
+to `run`.
+
+```python
+class InputIterator(Generic[T]):
+  """An input iterator, intended to be passed to `Replicator.run`."""
+
+  def get_next(self) -> List[T]:
+    """Returns the next inputs for each replica."""
+
+  def reinitialize(self) -> List[tf.Operation]:
+    """Re-initializes the inputs."""
+```
+
+### Model Parallelism
+
+Model parallelism can allow the execution of models when there is insufficient
+memory on a single device (and further data parallelism is not possible).
+
+Replicator supports model partitioning, a form of model parallelism in which the
+ops within the model are placed onto multiple devices. This is done via the
+`logical_device` context.
+
+Inputs are always located on logical device 0. Ops within the step function
+default to logical device 0 (except on TPU, which defaults to automatic
+placement).
+
+```python
+with replicator.scope():
+  with replicator.logical_device_for_variables(1):
+    v = tf.get_variable(...)  # On logical device 1.
+    x = v * 3  # Ignores logical device context.
+
+def step(ctx, inputs):  # `inputs` on logical device 0.
+  a = model_part1(inputs)  # Implicitly on logical device 0.
+  with ctx.logical_device(0):
+    b = model_part2(a)  # Explicitly on logical device 0.
+  with ctx.logical_device(1):
+    return model_part3(b)  # Explicitly on logical device 1.
+```
+
+### Eager mode support
+
+Eager mode support mostly drops out of building atop of `DistributionStrategy`.
+The entire API is designed to be eager compatible. We've called out the
+difference in behavior in eager and graph mode in the specific API
+documentations. In general, in graph mode, many of the APIs return ops which
+should be later executed with `session.run`, and in eager mode, they simply run
+the ops.
+
+## Usage Examples
+
+### Building a Replicator object
+
+The first step is to build a `Replicator` instance for the chosen platform:
+
+```python
+dist_strat = ...  # Create `DistributionStrategy` for a specific regime.
+replicator = tf.replicator.Replicator(dist_strat)
+```
+
+### Simple Classification
+
+Below is a simple usage example for an image classification use case.
+
+#### Training
+
+```python
+with replicator.scope():
+  model = resnet.ResNetV1(resnet.BLOCKS_50)
+  optimizer = tf.train.MomentumOptimizer(learning_rate, 0.9)
+
+def input_fn(ctx):
+  assert effective_batch_size % ctx.num_replicas_in_sync == 0
+  return imagenet.ImageNet(effective_batch_size // ctx.num_replicas_in_sync)
+
+def step_fn(ctx, input):
+  del ctx  # Unused.
+  image, label = input
+  logits = tf.squeeze(model(images))
+  cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
+      logits=logits, labels=label)
+  loss = tf.reduce_mean(cross_entropy)
+  train_op = optimizer.minimize(loss)
+  with tf.control_dependencies([train_op]):
+    return tf.identity(loss)
+
+inputs = replicator.prepare_input(input_fn)
+per_replica_losses = replicator.run(step_fn, inputs)
+mean_loss = tf.reduce_mean(tf.stack(per_replica_losses))
+
+with tf.Session() as session:
+  session.run(replicator.initialize())
+  for _ in xrange(num_train_steps):
+    loss = session.run(mean_loss)
+  session.run(replicator.finalize())
+```
+
+#### Evaluation
+
+```python
+with replicator.scope():
+  model = resnet.ResNetV1(resnet.BLOCKS_50)
+
+def eval_input_fn(ctx):
+  del ctx  # Unused.
+  return imagenet.ImageNet(
+      eval_batch_size, subset="valid", shuffle=False, num_epochs=1)
+
+def eval_top1_accuracy(ctx, input):
+  del ctx  # Unused.
+  image, label = input
+  logits = tf.squeeze(model(images))
+  predicted_label = tf.argmax(logits, axis=1)
+  top_1_acc = tf.reduce_mean(
+      tf.cast(tf.equal(predicted_label, label), tf.float32))
+  return top1_acc
+
+eval_inputs = replicator.prepare_input(
+    eval_input_fn, replication_mode=InputReplicationMode.SINGLE)
+per_replica_top1_accs = replicator.run(eval_top1_accuracy, eval_inputs)
+mean_top1_acc = tf.reduce_mean(tf.stack(per_replica_top1_accs))
+
+with tf.Session() as session:
+  session.run(replicator.initialize())
+  while True:
+    while not has_new_checkpoint():
+      sleep(60)
+
+    load_checkpoint()
+
+    # Do a sweep over the entire validation set.
+    session.run(eval_inputs.reinitialize())
+    while True:
+      try:
+        top1_acc = session.run(mean_top1_acc)
+        ...
+      except tf.errors.OutOfRangeError:
+        break
+  session.run(replicator.finalize())
+```
+
+#### Sharded Input Pipeline
+
+This example shows an alternate input function which reads different files on
+different input pipelines. It illustrates the use of input_pipeline_id from the
+`InputContext`.
+
+```python
+def input_fn(ctx):
+  d = tf.data.Dataset.list_files(file_pattern, shuffle=False)
+  d = d.shard(ctx.num_input_pipelines, ctx.input_pipeline_id)
+  d = d.repeat(num_epochs)
+  d = d.shuffle(shuffle_buffer_size)
+  d = d.interleave(tf.data.TFRecordDataset, cycle_length=num_readers)
+  d = d.map(parser_fn)
+
+  assert effective_batch_size % ctx.num_replicas_in_sync == 0
+  return d.batch(effective_batch_size // ctx.num_replicas_in_sync)
+
+```
+
+### GAN
+
+Below is a usage example for a GAN which uses two optimizers in the step
+function.
+
+```python
+def sample_noise(batch_size):
+  return tf.truncated_normal(
+      shape=(batch_size, num_latents), mean=0.0, stddev=1.0)
+
+def input_fn(ctx):
+  assert effective_batch_size % ctx.num_replicas_in_sync == 0
+  batch_size = effective_batch_size // ctx.num_replicas_in_sync
+  ds = cifar.Cifar10(batch_size)
+  return ds.map(lambda x: (x['image'], sample_noise(batch_size)))
+
+with replicator.scope():
+  discriminator = GoodfellowDiscriminator(DefaultDiscriminator2D())
+  generator = DefaultGenerator2D()
+  gan = GAN(discriminator, generator)
+  disc_optimizer = tf.train.AdamOptimizer(disc_learning_rate, beta1=0.5, beta2=0.9)
+  gen_optimizer = tf.train.AdamOptimizer(gen_learning_rate, beta1=0.5, beta2=0.9)
+
+def discriminator_step(ctx, input):
+  del ctx  # Unused.
+  image, noise = input
+  gan_output = gan.connect(image, noise)
+  disc_loss, disc_vars = gan_output.discriminator_loss_and_vars()
+  disc_train_op = disc_optimizer.minimize(disc_loss, var_list=disc_vars)
+
+  with tf.control_dependencies([disc_train_op]):
+    return tf.identity(disc_loss)
+
+def generator_step(ctx, input):
+  del ctx  # Unused.
+  image, noise = input
+  gan_output = gan.connect(image, noise)
+  gen_loss, gen_vars = gan_output.generator_loss_and_vars()
+  gen_train_op = gen_optimizer.minimize(gen_loss, var_list=gen_vars)
+
+  with tf.control_dependencies([gen_train_op]):
+    return tf.identity(gen_loss)
+
+inputs = replicator.prepare_input(input_fn)
+per_replica_disc_losses = replicator.run(discriminator_step, inputs)
+per_replica_gen_losses = replicator.run(generator_step, inputs)
+mean_disc_loss = tf.reduce_mean(tf.stack(per_replica_disc_losses))
+mean_gen_loss = tf.reduce_mean(tf.stack(per_replica_gen_losses))
+
+with tf.Session() as session:
+  session.run(replicator.initialize())
+  for _ in xrange(num_train_steps):
+    for _ in xrange(num_disc_steps):
+      disc_loss = session.run(mean_disc_loss)
+    for _ in xrange(num_gen_steps):
+      gen_loss = session.run(mean_gen_loss)
+  session.run(replicator.finalize())
+```
+
+### Reinforcement Learning
+
+This is an example of
+[IMPALA](https://deepmind.com/blog/impala-scalable-distributed-deeprl-dmlab-30/)-like
+Reinforcement Learning system, converted to eager mode.
+
+```python
+tf.enable_eager_execution()
+
+with replicator.scope():
+  agent = Agent(num_actions, hidden_size, entropy_cost, baseline_cost)
+  optimizer = tf.train.RMSPropOptimizer(learning_rate)
+
+# Queues of trajectories from actors.
+queues = []
+def learner_input(ctx):
+  del ctx  # Unused.
+  queue = tf.FIFOQueue(
+      capacity=1, dtypes=trajectory_dtypes, shapes=trajectory_shapes)
+  queues.append(queue)
+
+  def dequeue_batch():
+    batch = [Transition(*queue.dequeue()) for _ in xrange(batch_size_per_replica)]
+    # Stack the `Tensor` nests along axis 1.
+    return tf.nest.map_structure(lambda *xs: tf.stack(xs, axis=1), *batch)
+  return dequeue_batch
+
+def learner_step(ctx, trajectories):
+  del ctx  # Unused.
+  loss = tf.reduce_sum(agent.compute_loss(trajectories))
+  agent_vars = agent.get_all_variables()
+  optimizer.minimize(loss, var_list=agent_vars)
+  return loss, agent_vars
+
+# Create learner inputs.
+learner_inputs = replicator.prepare_input(learner_input)
+
+def run_actor(actor_id):
+  queue = queues[actor % len(queues)]
+  for _ in xrange(num_trajectories_per_actor):
+    observation = get_observation_from_environment()
+    action_taken, logits, _ = agent(tf.expand_dims(observation, axis=0))
+    trajectory = Transition(observation, action_taken, ...)
+    queue.enqueue(tf.nest.flatten(trajectory))
+
+# Start the actors.
+for actor_id in xrange(num_actors):
+  threading.Thread(target=run_actor, args=(actor_id,)).start()
+
+# Run the learner.
+replicator.initialize()
+
+for _ in xrange(num_train_steps):
+  per_replica_outputs = replicator.run(learner_step, learner_inputs)
+  per_replica_losses, updated_agent_var_copies = zip(*per_replica_outputs)
+  mean_loss = tf.reduce_mean(tf.stack(per_replica_losses))
+
+replicator.finalize()
+```
+
+### Global Batch Normalization
+
+When using a standard batch normalization layer with Replicator, the calculated
+mean and variance will be with-respect-to the local batch. A global batch
+normalization layer could be built using the `all_sum` method.
+
+```python
+def global_batch_norm(ctx, x):
+  local_x_mean = tf.reduce_mean(x, axis=0)
+  local_x_squared_mean = tf.reduce_mean(tf.square(x), axis=0)
+  global_x_mean, global_x_squared_mean = (
+      ctx.all_sum([local_x_mean / ctx.num_replicas_in_sync,
+                   local_x_squared_mean / ctx.num_replicas_in_sync])
+  global_x_variance = (
+      global_x_squared_mean - tf.stop_gradient(tf.square(global_x_mean)))
+  return tf.nn.batch_normalization(
+      x, global_x_mean, global_x_variance, offset=None, scale=None)
+```
+
+## Alternatives Considered
+
+### Using the `DistributionStrategy` API directly
+
+The low-level `DistributionStrategy` API has converged quite strongly towards
+the Replicator API is several places. However, we feel there are sufficient
+areas in which exposing researchers directly to the `DistributionStrategy` API
+is undesirable to justify a level of abstraction above it. The
+`DistributionStrategy` API is designed for flexibility and is used in a lot of
+TensorFlow components internally. It has evolved to be quite an extensive API
+and it would be impractical to expect most ML users to use the API directly. It
+would require them to figure out which methods are useful for them and which are
+not, and be more error-prone.
+
+Replicator provides a narrow and simpler API on top of Distribution Strategy
+that should be sufficient for most use cases. It has been tested internally with
+a significant number of researchers in Alphabet which gives us this confidence.
+It also allows users to do things in fewer API calls than Distribution Strategy.
+
+### Multiple `Replicator` implementations
+
+We considered having separate implementations for different hardware
+architectures (`MultiGpuReplicator`, `TpuReplicator`, etc.). It was decided to
+instead create a single implementation which takes a `DistributionStrategy`
+instance.
+
+### `num_steps_per_run` parameter
+
+We considered including a `num_steps_per_run` parameter on the `run` method
+which would run multiple steps for every call to `run`. This can give better
+performance as it amortizes some of the communication overheads. We don't
+believe this is necessary, as users should be able to recover any performance
+losses from its omission by wrapping the call to `run` in a `tf.while_loop`.
+
+### Stacking `run` outputs
+
+One option is that `replicator.run` returns a nest of stacked tensors, with an
+additional leading dimension of size `num_replicas_in_sync`.
+
+We decided instead of stacking the per replica tensors, we will return a list of
+nests instead. This is because for large outputs (e.g. RL agent variables), in a
+multi-worker configuration, stacking would force them to be copied to one of the
+hosts (host 0) which seems unnecessarily restrictive.
+
+### Allow users to specify `per_replica_batch_size` and `effective_batch_size`?
+
+This is a common feature request from existing users of the prototype. We feel
+that the properties provided by `InputContext` solve this problem more
+elegantly.
+
+### Naming
+
+We considered a few different names for some things.
+
+#### Unit of computation / context
+
+1.  replica
+1.  tower
+
+Decided "replica" based on popular opinion (through a survey).
+
+#### Machines
+
+1.  worker
+1.  host
+
+Replicator and Distribution Strategy previously used both. Decided on "worker"
+by popular opinion. Also, using worker leaves open the possibility that we may
+have multiple hosts per worker in the case of very large models.
+
+#### Input pipeline
+
+We considered "input replica" and "input shard" but none of those capture the
+variety of use cases so we agreed on "input pipeline" which doesn't necessarily
+say they're copies of each other, or are sharded.
+
+## Questions and Discussion Topics
+
+*   Should `InputReplicationMode` be called something else? `InputPipelineMode`?
+    `InputMode`? Relatedly, is `SINGLE` a good name for the case where there is
+    one input pipeline?
+*   Should this live under the distribution strategy directory
+    (tensorflow/python/distribute) or a new directory? Similarly, should the API
+    be in `tf.distribute` namespace or a new namespace (`tf.replicate`)?
+*   Certain distribution strategies are between-graph
+    (CollectiveAllReduceStrategy and ParameterServerStrategy). In those cases,
+    should the `Replicator.run` method return outputs only from the replicas in
+    that graph? Or should we try to return outputs from all graphs? Do we need
+    to add more properties like “num_replicas_in_graph” ?

--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -1,81 +1,34 @@
-# Replicator API
+# Distribution Strategy - Revised API
 
-| Status        | Proposed                                                |
-| :------------ | :------------------------------------------------------ |
-| **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, petebu@google.com, priyag@google.com |
-| **Sponsor**   | joshl@google.com                                        |
-| **Updated**   | 2018-10-17                                              |
+| Status        | Proposed                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, joshl@google.com, |
+|               | petebu@google.com, priyag@google.com, tomhennigan@google.com              |
+| **Sponsor**   | wicke@google.com                                                          |
+| **Updated**   | 2018-10-31                                                                |
 
 ## Objective
 
-This document presents a proposal to add a new API in TensorFlow for replicating computation across
-different GPUs, TPUs and multiple machines. It will be implemented as a thin
-usability API layer on top of
-[DistributionStrategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy).
+This document presents a proposal to seek feedback on a revised [Distribution Strategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy) API and illustrate its usage in various situations. Distribution Strategy aims to allow users to easily distribute their computation across 
+different GPUs, TPUs and multiple machines. Until now, the recommended usage of Distribution Strategy has been through TensorFlow high level training frameworks such as [`tf.keras`](https://www.tensorflow.org/guide/keras) and [`Estimator`](https://www.tensorflow.org/guide/estimators). In this proposal, we want to show how one can use Distribution Strategy APIs directly for distributing custom training loops, and get feedback on those APIs. This use case is important for many users who want more control of their training loops, such as ML researchers. We have tested a similar version of this API internally with many researchers in Alphabet and the current proposal is based on their feedback.
 
-The Replicator API will be primarily targeted at ML researchers, who often
-require greater flexibility than is exposed by the high-level APIs (e.g.
-Estimator, Keras which are already integrated with Distribution Strategy
-directly). This would provide TF users with research-focused API that has
-already been "battle-tested" by internal Alphabet users. Replicator will be TF
-2.0 and Eager-mode ready.
+This is also an opportune time to get public feedback as we are in the process of migrating Distribution Strategy APIs from `tf.contrib` to core TensorFlow (as part of TF 2.0). As part of the move, we want to improve and reorganize the APIs to make them more user friendly and understandable.
+
 
 ## Overview
 
-### Replicator
 
-Replicator will be a TensorFlow library to transparently replicate computation
+[Distribution Strategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy) is a TensorFlow library to transparently replicate computation
 across several machines / GPUs / TPUs.
 
-Replicator's design aspirations include:
+Distribution Strategy’s design aspirations include:
 
-*   Highly usable for the majority of researchers.
 *   User-friendly minimal API.
+*   Highly usable for multiple user segments, including researchers, ML engineers, etc.
 *   Equal performance to manually replicated code.
 
-To use this API, the user creates a `Replicator` object with the appropriate
-distribution strategy instance. Then they build the graph / executes
-computations using Replicator primitives. They can then trivially switch their
-code to work with 1-GPU / n-GPUs / multi-worker-GPU / TPU by changing the
-distribution strategy passed to the `Replicator`.
 
-Unlike `Estimator` and `tf.Keras` APIs, Replicator:
-
-*   Allows / requires the user to write their own main training loop.
-*   Easily supports multiple inputs, outputs and optimizers in the model. One
-    can write a custom Estimator which has multiple optimizers but this would be
-    rather cumbersome.
-
-The Replicator API has been prototyped internally and refined in collaboration
-with Alphabet researchers.
-
-### Distribution Strategy
-
-[DistributionStrategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy)
-is a flexible low-level API that can be used to distribute computation across
-over machines / GPUs / TPUs. So in this sense, it has the same goals as
-Replicator.
-
-Distribution Strategy’s low level APIs are now well integrated into Estimator
-and Keras high level APIs. Users can now distribute their code written with
-Estimator and Keras APIs to GPUs/TPUs/multiple machines with typically only 2-3
-lines of code changes
-([see example usage](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/README.md)).
-
-Distribution Strategy’s low level APIs can be directly used to distribute
-training programs written with low level TensorFlow APIs (i.e. without
-Estimator/Keras). But it can be tedious and error prone as it exposes an
-extensive and flexible API. There is a skeleton of a mid-level API within
-Distribution Strategy
-([`Step`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/python/step_fn.py),
-[`Monitor`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/python/monitor.py))
-where users can write their own main-loops more easily, but this has not yet
-been developed fully or tested with real users.
-
-Hence, adding the Replicator API layer on top of Distribution Strategy APIs
-fills this gap for users who require more flexibility in their training loops.
-
-Distribution Strategy now supports a number of different strategies:
+Distribution Strategy (DS) now supports a number of different strategies:
 
 *   `MirroredStrategy` for synchronous
     ([in-graph](https://www.tensorflow.org/deploy/distributed)) training across
@@ -84,27 +37,73 @@ Distribution Strategy now supports a number of different strategies:
     ([between-graph)](https://www.tensorflow.org/deploy/distributed) training
     across multiple machines.
 *   `TPUStrategy` for using TPUs.
-*   `ParameterServerStrategy` for async parameter server training.
+*   `ParameterServerStrategy` for asynchronous parameter server training.
 
-## Design
+Different users will use DS in different ways. We have classified the possible use-cases into four categories.
+
+#### Use case #1: `tf.keras` / `Estimator` API users
+
+A large majority of TensorFlow users who are interested in scaling up their computation will likely be using one of the two high-level training frameworks: `tf.keras` and `Estimator`. For these users, using Distribution Strategy should be very simple: they just need to create an object of the strategy type based on their platform, and pass it to `keras` / `Estimator` APIs. We show some usage examples in the next section. These users only need to use the constructors of the various `DistributionStrategy` classes (such as [`MirroredStrategy`](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/MirroredStrategy)).
+
+#### Use case #2: Users who write their own outer training loop
+
+Some users (such as researchers) require more flexibility and control over their training loops. This makes it hard for them to use the high level frameworks such as Estimator or tf.keras. For instance, someone using a GAN may want to do different number of steps of generator and discriminator in each round. Similarly, the high level frameworks are not very suitable for Reinforcement Learning training. So these users will usually write their own training loops. For these users, we will expose a core set of methods through the Distribution Strategy classes. The user will first create an object of the appropriate strategy class. Then they will use a few methods on the strategy object to build the replicated graph / run the replicated computation. This requires minor restructuring of the code initially, but once that is done, the user should be able to switch between GPUs / TPUs / multiple machines by changing the strategy instance. 
+
+These APIs have been prototyped internally and refined in collaboration
+with Alphabet researchers. We hope that they will be useful for many TensorFlow users. This use-case will be the main focus of this design document.
+
+#### Use case #3: Users who will create custom distributed layers
+
+Most of the users that write their custom outer training loops will rely on common TensorFlow components to handle communication between replicated computation. For instance, TensorFlow optimizers will automatically take care of aggregating the gradients across replicas. Some users, however, may have complex models where they want to do custom distributed communication in the middle of their model, e.g. insert an all-reduce operation.
+
+For example, some users may want to write a custom layer to do cross-replica batch normalization. For such users, we provide additional methods such as all-reduce and broadcast to facilitate communication between replicas. Since these use cases are uncommon, we will abstract away these methods under an `extended` property of the main DistributionStrategy class.
+
+#### Use case #4: Users who will create new `DistributionStrategy` implementations
+
+We hope that some users will extend the `DistributionStrategy` class and create new implementations. For instance, authors of [Horovod](https://github.com/uber/horovod) are collaborating with TensorFlow team to create a new `HorovodDistributionStrategy`. These users of course will need to understand and implement the entire surface area of the Distribution Strategy API. 
+
+
+
+## Integration with tf.keras and Estimator
+
+As mentioned before, the majority of TensorFlow users will use Distribution Strategy through one of the high level training frameworks - `tf.keras` and `Estimator`. Users can distribute their code written with these APIs to GPUs / TPUs / multiple machines with typically only 2-3 lines of code changes. We’ve modified the `tf.keras` and `Estimator` backends, as well as many TensorFlow components (such as optimizers, metrics, and layers), to be Distribution Strategy aware. The user only needs to decide which strategy type they want to use for their platform. The rest is taken care of by the framework.
+
+This usage has been covered in the Distribution Strategy [README document] (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/README.md). Here is a simple example of scaling training in tf.keras to multiple GPUs:
+
+```python
+inputs = tf.keras.layers.Input(shape=(1,))
+predictions = tf.keras.layers.Dense(1)(inputs)
+model = tf.keras.models.Model(inputs=inputs, outputs=predictions)
+dataset = tf.data.Dataset.zip((features, labels))
+strategy = tf.distribute.MirroredStrategy()
+model.compile(loss='mean_squared_error',
+              optimizer=tf.train.GradientDescentOptimizer(learning_rate=0.2),
+              distribute=strategy)
+model.fit(dataset, epochs=5, steps_per_epoch=10)
+```
+
+As you can see, the only distribution-specific changes for the users are creating the `MirroredStrategy` object, and pass it to the compile call. They don’t need to know / use any other APIs of `MirroredStrategy` - `keras` and other TF components will do that on their behalf.
+
+
+## Design 
+
+In this section, we describe the core DS APIs in detail, with a focus on use case #2 (users writing custom training loops). We will also talk briefly about some of the extended APIs and how to access them.
 
 ### Overview
 
-The basic idea of the Replicator API is that the user can write their code as if
-it was running on a single device. By adding just a few lines of Replicator
-code, the computation can then be run across multiple machines and / or devices.
+The basic idea is that the user can write their code as if it was running on a single device. By adding just a few lines of DS code, the computation can then be run across multiple machines and / or devices.
 The computation that is running on each device is a [replica](#replica) of the
 user computation (assuming no [model parallelism](#model-parallelism) across
 devices).
 
-The Replicator API provides a number of primitives to facilitate communication
+The DS API provides a number of primitives to facilitate communication
 across replicas. The most common use case is the aggregation of gradients for
-synchronous SGD training. Replicator natively supports this by automatically
+synchronous SGD training. DS natively supports this by automatically
 adding cross-replica gradient accumulation to any TensorFlow optimizer created
-within a replicator scope (see the
+within a DS scope (see the
 [Simple Classification](#simple-classification) example below). For more
 advanced use cases (such as cross-replica batch normalisation), the API provides
-MPI-like primitives for sending and receiving tensors across replicas.
+collective operations for sending and receiving tensors across replicas.
 
 The TF sub-graph generating input data is treated separately from the sub-graph
 performing the main computation (e.g. training a model). This decoupling
@@ -121,20 +120,23 @@ that code can be seamlessly moved between different device targets.
 #### Replica
 
 A replica is "one copy of the computation" that the user wants to replicate. You
-can think of it as "one copy of the model". In distribution strategy, this was
-formerly known as a "tower". We might also refer to this as "compute replica" or
+can think of it as "one copy of the model". We might also refer to this as "compute replica" or
 "model replica" in some places.
 
 When using model parallelism, a replica will span several physical devices (e.g.
 GPUs, TPU cores) and may also span multiple physical machines.
 
+`replica_id` will range from 0 to N-1 if N is the number of replicas.
+
 #### Worker
 
 The physical machine(s) containing the physical devices (e.g. GPUs, TPUs) on
 which the replicated computation is executed. A worker may contain one or more
-replicas. Typically one worker will correspond to one host machine, but in the
+replicas, but contains at least one replica. Typically one worker will correspond to one machine, but in the
 case of very large models with model parallelism, one worker may span multiple
-hosts.
+machines.
+
+`worker_id` will range from 0 to N-1 if N is the number of workers.
 
 #### Sync vs Async replicas
 
@@ -143,73 +145,75 @@ are aggregated across all the replicas. In fully asynchronous training, all
 replicas operate asynchronously and update the variables independently. We can
 also support a hybrid approach, where the replicas are divided into "sync
 groups" - within each sync group, each replica is in sync, but the sync groups
-are asynchronous among themselves. To support this, we later define
-"num_replicas" as the total number of replicas (sync or async) and
-"num_replicas_in_sync" as the number of replicas in one sync group.
+are asynchronous among themselves. To support this, we later define 
+`num_replicas_in_sync` as the number of replicas in each sync group, as well as `num_sync_groups` as the number of sync group that are executing concurrently.
+
+#### Logical device 
+In model parallelism, a replica will span several physical devices. The user will partition their model by specifying the physical device within a replica for variables and ops. Let’s say we have M replicas and each replica spans N devices. We will say we have N “logical devices”, numbered from 0 to N-1. We have total M*N physical devices, which will typically only be named by their device strings. See [Model Parallelism](#model-parallelism) section for more details.
 
 #### Input Pipeline
 
-An instance of the input pipeline (e.g. `Dataset`, `FIFOQueue`) obtained by
-calling the user's `input_fn` once. One input pipeline may be used to feed one
-or more model replicas (on one or more workers). See
-[InputReplicationMode](#inputreplicationmode).
+A single instance of the user’s input source, obtained by
+calling the user's input function. We may have multiple input pipelines if we call the input function multiple times, let’s say once per worker. Also, one input pipeline may be used to feed one
+or more model replicas (on one or more workers). See [InputReplicationMode](#inputreplicationmode).
 
-### Replicator API
+`input_pipeline_id` will range from 0 to N-1 if N is the number of input pipelines.
 
-#### Detailed Design
 
-Here are the main ingredients of the API:
+### New Distribution Strategy API
 
-*   `Replicator` class: This is the main class of the API and provides the main
-    methods to replicate the computation.
-    *   `__init__:`Creates a Replicator instance. It takes a
-        `DistributionStrategy` object which is used for (almost) all the
-        underlying operations such as replicating the computation, all-reduce
-        etc.
+#### Main ingredients of the API
+
+*   `DistributionStrategy` class: This is the main class of the API and provides the main
+    methods to distribute the computation.
     *   `scope`: A context manager that manages variable creation correctly
-        within its scope, and also sets the distribution strategy as current for
-        the current graph & thread. Variables that need to be replicated must be
-        created within `Replicator.scope`, unless they are created inside the
+        within its scope. Variables that need to be replicated must be
+        created within `DistributionStrategy.scope`, unless they are created inside the
         `fn` passed to `run` which automatically wraps the entire `fn` inside
-        `Replicator.scope`. Entering a `scope` twice is safe, so in general,
-        enclosing everything that is potentially distributed inside a `scope`
-        should be safe.
+        `DistributionStrategy.scope`. Entering a `scope` again with the same strategy doesn’t have any impact.
     *   `run`: This method is used to replicate the computation. It takes a
         function `fn` which specifies the computation, and an (optional)
-        `InputIterator` `inputs` to be fed into`fn`. It calls `fn` with one
+        `InputIterator` `inputs` to be fed into `fn`. It calls `fn` with one
         element from the input iterator within distribution strategy `scope`.
         Variables and optimizers for the model can be created inside or outside
         `fn`, as long as they're created within `scope`. `run` can be called
         multiple times with different `fn`. In graph mode, run simply creates
-        the replicated graph whereas in eager mode, it will run the actual
+        the replicated graph whereas when eager execution is enabled, it will run the actual
         computation. It then returns the list of outputs of `fn` from each
         replica.
-    *   `prepare_input`: This method is used to prepare the input for being
-        passed to run. It takes an `InputFn` `fn` which either returns a
-        `Dataset` or a function which returns
-        ([nests](https://www.tensorflow.org/api_docs/python/tf/contrib/framework/nest)
-        of) input tensors. It also takes an optional `InputReplicationMode`
+    *   `make_input_iterator`: This method is used to create the input iterator that is passed to run. It takes an `input_fn` which either returns a
+        `Dataset` or a function which returns a nested structure of input tensors. It also takes an optional `InputReplicationMode`
         `replication_mode` which specifies how, if at all, the input fn should
         be replicated. The current options are (1) no replication, (2) replicate
         per worker (default option), and (3) replicate per compute-replica. See
         [InputReplicationMode](#inputreplicationmode) section for more details.
         It returns an `InputIterator` which should be passed into `run` for
-        consumption according to the distribution strategy. `prepare_input` can
-        be called multiple times as well, potentially to get different inputs
+        consumption according to the distribution strategy. `make_input_iterator` can
+        be called multiple times as well, potentially to get different iterators
         being passed to different calls to `run`.
     *   `initialize` / `finalize`: This returns ops that should be run before
         and after running replicated computations, respectively. Typically this
         would contain things like TPU initialize / finalize ops, and dataset
-        iterator initialize ops. In eager mode, this will instead run the
+        iterator initialize ops. When eager execution is enabled, this will instead run the
         initialize and finalize ops directly instead of returning them.
-*   `ReplicaContext`: This is an object that is passed as the first argument to
-    `fn` when called with `run`. It contains information about the replication
-    context, such as the number of replicas, current replica id etc. It also
+    *   `extended`: This property returns an instance of a class implementing extended
+        Distribution Strategy functionality. See `DistributionStrategyExtended` for more details.
+*   `DistributionStrategyExtended`: This class contains the additional `DistributionStrategy`
+     functionality. This will contain methods that will typically be only needed by users
+     that fall under use case #3 and #4. To a large extent, this will include the existing
+     [DistributionStrategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy)
+     methods and properties except the ones that will now be exposed in the main class. See below for details.
+
+*   Module level functions: Functions in `tf.distribute` that can be accessed from anywhere and provide information about a distributed context that might currently be active. These are typically useful only in advanced use cases. Note that a distributed context is local to the current thread, and is stored in the current graph. So changing the graph, or the thread, means you could be in a different (or no) distribution strategy context. 
+    *   `get_replica_context`: This method retrieves the current `ReplicaContext` or None if in a cross-replica context. 
+    *   `get_cross_replica_context`: Returns the current `DistributionStrategy` if in a cross-replica context, otherwise None. 
+
+*   `ReplicaContext`: This is an object that can be obtained via the `get_replica_context()` method. It contains information about the replication context, such as the number of replicas, current replica id etc. It also
     provides the methods for communication across replicas such as `all_sum`,
-    `broadcast`, etc.
+    `broadcast`, etc. This is useful for use cases #3, for e.g. when writing custom layers.
 *   Input: Replicating and distributing the input correctly across replicas is
     an important component of replicating the computation. The API provides a
-    number of input related functionality to support different use cases.
+    number of input related functionality to support different use cases. Currently, input can be specified through an input function that returns a dataset or a function that returns input tensors. In the future, we will support providing an already created dataset and distribute input from that efficiently. 
     *   `InputReplicationMode`: The user may want to use the same input pipeline
         for all their replicas, or have a separate input pipeline per worker or
         per replica. This mode allows the user to specify which mode they want.
@@ -224,148 +228,137 @@ Here are the main ingredients of the API:
         subset of the input in each input pipeline (for e.g. shard the input
         pipeline, use a different input source etc).
     *   `InputIterator`: This is a new type of iterator returned by
-        `prepare_input` which should be passed to `replicator.run`. If the user
-        chooses to implement their own input preparation, they can also simply
-        implement this API (instead of using `replicator.prepare_input`). They
-        will be responsible for any initialization for such input pipeline
-        themselves.
+        `make_input_iterator` which should be passed to `strategy.run`. Users should call `initialize` method on the returned iterator if their input_fn returns a `tf.data.Dataset`. They can also use it anytime they want to start processing the input from the beginning. 
 
 The typical usage of this API is as follows:
 
-*   Define a replicator instance with the appropriate distribution strategy.
-*   Create the model and optimizer within the replicator scope.
+*   Instantiate the appropriate distribution strategy class.
+*   Create the variables (model parameters, optimizer variables etc) within the distribution strategy scope.
 *   Define an input function which returns the input for the computation.
-    Replicate it using `replicator.prepare_input`.
+    Prepare it for being used in your distributed computation using `strategy.make_input_iterator`.
 *   Define a step function which takes input as argument and does a single step
-    of computation.
-*   Replicate the step function with `replicator.run` passing it the replicated
+    of computation. The variables can be defined within the step function as well (instead of outside).
+*   Replicate the step function with `strategy.run` passing it the replicated
     input.
 
 Next, we will show the code for the API as well as sample usage examples.
 
-#### Replicator class
+#### DistributionStrategy class
+
+This is the main API that use cases #2 will need to use to distribute custom training loops.
 
 ```python
-Nest = ...  # Type supported by `tf.nest`.
+Nest = ...  # A type representing a nested structure of elements such as nested sequence, tuple or dict.
 T = TypeVar("T", Nest[tf.Tensor])  # A generic `Tensor` nest.
 U = TypeVar("U", Nest[tf.Tensor])  # Another generic `Tensor` nest.
 
 InputGenerator = Callable[[], T]
 InputFn = Callable[[InputContext], Union[tf.data.Dataset, InputGenerator[T]]]
 
-class Replicator(object):
-
-  def __init__(self, distribution: DistributionStrategy):
-    """Creates a `Replicator` with the given distribution strategy."""
+class DistributionStrategy(object):
 
   def initialize(self) -> List[tf.Operation]:
     """Initialization to be performed before running any computations.
 
-    In eager mode, it performs any necessary initialization.
-    In graph mode, it creates initialization ops and returns them.
-
-    In graph mode, the returned list will include the initialization ops for any
-    `tf.data.Dataset` iterators created by preceding calls to `prepare_input`.
+    When eager execution is enabled, it performs any necessary initialization.
+    Otherwise, it creates initialization ops and returns them.
 
     Returns:
-      In eager mode, returns an empty list.
-      In graph mode, returns the list of ops to execute.
+      When eager execution is enabled, returns an empty list.
+      Otherwise, returns the list of ops to execute.
     """
 
   def finalize(self) -> List[tf.Operation]:
     """Finalization to be performed after the end of all computations.
 
-    In eager mode, it performs any necessary finalization.
-    In graph mode, it creates finalization ops and returns them.
+    When eager execution is enabled, it performs any necessary finalization.
+    Otherwise, it creates finalization ops and returns them.
 
     Returns:
-      In eager mode, returns an empty list.
-      In graph mode, returns the list of ops to execute.
+      When eager execution is enabled, returns an empty list.
+      Otherwise, returns the list of ops to execute.
     """
 
   def scope(self) -> ContextManager:
-    """Returns a context for model / `Variable` creation.
-
-    Models used within `run` must be created in this scope, so that `Variable`s
-    can be correctly replicated and / or placed on the correct devices.
+    """Returns a context for variable creation.
 
     N.B. This context is automatically applied within `run`.
     """
 
-  def prepare_input(
+  def update_session_config(self, session_config=None):
+    """Returns an updated session config with strategy specific optimizations. Creates a new config if none is given.
+
+    The returned config should be used to create any sessions, if needed.
+    """
+
+  def make_input_iterator(
       self,
-      fn: InputFn[T],
-      replication_mode: InputReplicationMode = InputReplicationMode.PER_WORKER,
-      prefetch_on_device: Optional[bool] = None,
-      enforce_ordering: bool = False) -> InputIterator[T]:
-    """Prepares the input data.
+      input_source: InputFn[T],
+      replication_mode: InputReplicationMode = InputReplicationMode.PER_WORKER) -> InputIterator[T]:
+    """Makes an iterator for input provided via an input function.
 
     Depending on the input replication mode, the input function may be called one time
     or several. We call the result of each call an “input pipeline”. Disjoint subsets of the compute
     replicas will draw their input data from each input pipeline. See `InputReplicationMode` for
     more details.
 
-    If `fn` returns an instance of `tf.data.Dataset`, a corresponding `tf.data.Iterator` will be
-    created. Each replica taking its input from this pipeline will execute `Iterator.get_next()`.
-    The `tf.data.Iterator`(s) can be re-initialized by calling the `reinitialize` on the returned
-    `InputIterator` object.
-
-    If `fn` returns a Python callable (e.g. `FIFOQueue.dequeue`), that callable will be executed on
-    each replica taking its input from this pipeline. `InputIterator.reinitialize` will have no effect on
-    this pipeline.
+    Returns an `InputIterator` which returns inputs for each step of the computation. User should call `initialize` on the returned iterator if their input_fn returns a `tf.data.Dataset`.
 
     Args:
-      fn: The input function.
+      input_source: The source of the input represented by an input function.
         The function must take an `InputContext` as the only parameter. It must return either
         an instance of `tf.data.Dataset` or a parameter-less Python callable that returns a
         `Tensor` nest.
       replication_mode: The input replication mode. Defaults to per-worker replication.
-      prefetch_on_device: Indicates whether to prefetch input data to the devices.
-        For now we use a buffer size of 1 for this prefetch.
-      enforce_ordering: Indicates whether to enforce input ordering.
-        If `True`, replicas will receive data from their respective sources
-        in replica ID order (i.e. replica 0 reads before replica 1, etc.).
     """
 
   @overload
-  def run(
-      self,
-      fn: Callable[[ReplicaContext], U]) -> List[U]:
+  def run(self, fn: Callable[[], U]) -> U:
+ 
   @overload
-  def run(
-      self,
-      fn: Callable[[ReplicaContext, T], U],
-      inputs: InputIterator[T]) -> List[U]:
-    """Replicates a computation on each replica, with the given inputs.
+  def run(self, fn: Callable[[T], U], iterator: InputIterator[T]) -> U:
+    """Runs `fn` on each replica, with inputs from `iterator`.
 
-    In eager mode, executes `fn` on each replica.
-    In graph mode, builds a graph to execute `fn` on each replica.
+    When eager execution is enabled, executes `fn` on each replica.
+    Otherwise, builds a graph to execute `fn` on each replica.
 
-    Each replica will take a single, different input from the list of inputs
-    provided by the input iterator.
+    Each replica will take a single, different input from the inputs
+    provided by one `get_next` call on the input iterator.
 
     IMPORTANT: Depending on the `DistributionStrategy` being used, `fn` may be
-    called one, or several, times.
+    called one, or several, times (one for each replica).
 
     Returns:
-      A list of the outputs from each replica.
+      Merged return value of `fn` across replicas. The structure of the return value is the same as the return value from each `fn`. Each element in the structure can either be a `PerReplica` value (when each replica returns a different value), or a `Mirrored` value (when each replica returns the same value but on different replicas).
     """
 
   def logical_device_for_variables(self, logical_device_id: int) -> ContextManager:
     """Returns a context to place variables on the given logical device."""
 
-  @property
-  def num_replicas(self) -> int:
-    """Returns the total number of replicas."""
+  def num_sync_groups(self) -> int:
+    """Returns the number of sync groups, where a sync group is a set of replicas training in sync."""
 
-  @property
   def num_replicas_in_sync(self) -> int:
     """Returns the number of replicas training in sync."""
+
+  def reduce(self, values: PerReplica[tf.Tensor], aggregation: AggregationType) -> tf.Tensor:
+    """Returns the result of aggregating `values` to the current device."""
+
+  def broadcast(self, value: tf.Tensor) -> PerReplica[tf.Tensor]:
+    """Broadcasts the given value from the current device to all replicas."""
+
+  def extended(self) -> DistributionStrategyExtended:
+    """Returns an instance of the class implementing additional DistributionStrategy functionality.
+    
+    The methods accessible through this property are useful for users who need custom distributed communication, as well as for users creating new DistributionStrategy types.
+
+    """
 ```
 
-#### ReplicaContext
 
-An instance of the `ReplicaContext` is passed to the function passed to `run`.
+#### ReplicaContext class
+
+An instance of the `ReplicaContext` can be retrieved by calling `tf.distribute.get_replica_context()`. This would be primarily used for use cases #3.
 
 ```python
 class ReplicaContext(object):
@@ -374,15 +367,14 @@ class ReplicaContext(object):
     "Returns the current replica ID."""
 
   @property
-  def num_replicas(self) -> int:
-    """Returns the total number of replicas."""
-
-  @property
   def num_replicas_in_sync(self) -> int:
     """Returns the number of replicas training in sync."""
 
   def logical_device(self, logical_device_id: int) -> ContextManager:
-    """Returns a context to place ops / variables on the given logical device."""
+    """Returns a context to place ops / variables on the given logical device.
+
+    The logical device ids are numbered 0 to N-1 where N is number of logical devices per replica. 
+    """
 
   def all_sum(self, value: T) -> T:
     """All-sums the given `Tensor` nest across replicas.
@@ -390,7 +382,7 @@ class ReplicaContext(object):
     If `all_sum` is called in any replica, it must be called in all replicas.
     The nested structure and `Tensor` shapes must be identical in all replicas.
 
-    IMPORTANT: The ordering of communications must be identical in all replicas.
+    IMPORTANT: The ordering of communications must be identical in all replicas. Otherwise an error will be thrown.
 
     Example with two replicas:
       Replica 0:: `value`: {'a': 1, 'b': [40,  1]}
@@ -413,7 +405,7 @@ class ReplicaContext(object):
     If `all_min` is called in any replica, it must be called in all replicas.
     The nested structure and `Tensor` shapes must be identical in all replicas.
 
-    IMPORTANT: The ordering of communications must be identical in all replicas.
+    IMPORTANT: The ordering of communications must be identical in all replicas. Otherwise an error will be thrown.
 
     Example with two replicas:
       Replica 0:: `value`: {'a': 1, 'b': [40,  1]}
@@ -427,7 +419,7 @@ class ReplicaContext(object):
         The structure must be compatible with `tf.nest`.
 
     Returns:
-       A `Tensor` nest with the element-wise minimum `value`s from each replica.
+       A `Tensor` nest with the element-wise minimum `value`s from each replica. Otherwise an error will be thrown.
     """
 
   def all_max(self, value: T) -> T:
@@ -450,7 +442,7 @@ class ReplicaContext(object):
         The structure must be compatible with `tf.nest`.
 
     Returns:
-       A `Tensor` nest with the element-wise maximum `value`s from each replica.
+       A `Tensor` nest with the element-wise maximum `value`s from each replica. Otherwise an error will be thrown.
     """
 
   def all_gather(self, value: T) -> T:
@@ -459,7 +451,7 @@ class ReplicaContext(object):
     If `all_gather` is called in any replica, it must be called in all replicas.
     The nested structure and `Tensor` shapes must be identical in all replicas.
 
-    IMPORTANT: The ordering of communications must be identical in all replicas.
+    IMPORTANT: The ordering of communications must be identical in all replicas. Otherwise an error will be thrown.
 
     Example with two replicas:
       Replica 0:: `value`: {'a': 1, 'b': [40,  1]}
@@ -475,7 +467,7 @@ class ReplicaContext(object):
     Returns:
        A `Tensor` nest with the `value`s from each replica. If a `Tensor` within
        `value` has shape `dims`, the returned `Tensor` will have shape
-       `[num_replicas] + `dims`.
+       `[num_replicas_in_sync] + `dims`.
     """
 
   def broadcast(self, value: T, source_replica_id: int) -> T:
@@ -485,7 +477,7 @@ class ReplicaContext(object):
     The nested structure, `Tensor` shapes, and `source_replica_id` must be
     identical in all replicas.
 
-    IMPORTANT: The ordering of communications must be identical in all replicas.
+    IMPORTANT: The ordering of communications must be identical in all replicas. Otherwise an error will be thrown.
 
     `value` will always be evaluated on all replicas.
 
@@ -504,9 +496,24 @@ class ReplicaContext(object):
     Returns:
       A `Tensor` nest with the `value` from the source replica.
     """
+
+  def merge_call(merge_fn, *args, **kwargs):
+    """Merge args across replicas and run `merge_fn` in a cross-replica context."""
 ```
 
-#### InputReplicationMode
+#### AggregationType enum
+
+```python
+class AggregationType(enum.Enum):
+  SUM = 1
+  MEAN = 2
+  ONLY_FIRST_REPLICA = 3
+  MIN = 4
+  MAX = 5
+```
+
+
+#### InputReplicationMode enum
 
 ```python
 class InputReplicationMode(enum.Enum):
@@ -521,14 +528,14 @@ The input function will be called once, typically on the first worker. The
 entire input pipeline ops then live on that worker. All replicas (on that and
 other workers) will dequeue from a single `Dataset` created on that worker.
 
-This mode is not supported by between-graph Distribution Strategy
+This mode is not supported by between-graph `DistributionStrategy`
 implementations.
 
 ##### PER_WORKER
 
 The input function will be called on each worker independently, creating as many
 input pipelines as number of workers. Replicas will dequeue from the local
-`Dataset` on their worker. Replicator doesn't manage any state sharing between
+`Dataset` on their worker. DS doesn't manage any state sharing between
 such separate input pipelines.
 
 ##### PER_REPLICA
@@ -537,16 +544,12 @@ The input function will be called for every replica, on the corresponding
 worker, thus creating as many input pipelines as number of replicas. Each
 replica will dequeue from its own `Dataset`.
 
-#### InputContext
+#### InputContext class
 
 An instance of `InputContext` is passed to the input function.
 
 ```python
 class InputContext(object):
-  @property
-  def num_replicas(self) -> int:
-    """Returns the total number of compute replicas."""
-
   @property
   def num_replicas_in_sync(self) -> int:
     """Returns the number of compute replicas training in sync."""
@@ -566,46 +569,98 @@ class InputContext(object):
 
     If `replication_mode` == `SINGLE`, this is always `1`.
     If `replication_mode` == `PER_WORKER`, this is the number of workers.
-    If `replication_mode` == `PER_REPLICA`, this is `num_replicas`.
+    If `replication_mode` == `PER_REPLICA`, this is total number of replicas.
     """
 ```
 
-#### InputIterator
+#### InputIterator class
 
-An instance of `InputIterator` is returned by `prepare_input` and can be passed
+An instance of `InputIterator` is returned by `make_input_iterator` and can be passed
 to `run`.
 
 ```python
 class InputIterator(Generic[T]):
-  """An input iterator, intended to be passed to `Replicator.run`."""
+  """An input iterator, intended to be passed to `DistributionStrategy.run`."""
 
-  def get_next(self) -> List[T]:
+  def get_next(self) -> PerReplica[T]:
     """Returns the next inputs for each replica."""
 
-  def reinitialize(self) -> List[tf.Operation]:
-    """Re-initializes the inputs."""
+  def initialize(self) -> List[tf.Operation]:
+    """Initializes the inputs."""
 ```
+
+#### DistributedValues 
+
+This set of classes represent an abstraction for values on multiple devices. Typically they would be used to Tensors / Variables, but they can also be used for other general objects if needed. We briefly introduce them here, but don’t go into the detailed API as most users should not need to use these APIs directly. 
+
+```python
+class DistributedValues(object):
+  """Holds a map from replica to values. Can be PerReplica or Mirrored."""
+
+class PerReplica(DistributedValues):
+  """Holds a map from replica to unsynchronized values."""
+
+class Mirrored(DistributedValues):
+  """Holds a map from replica to values which are kept in sync."""
+```
+
+#### DistributionStrategyExtended class
+
+This class contains additional `DistributionStrategy` functionality, which would be useful for use cases in category #3 - users who will use custom distributed communication, as well as for use cases in category #4 - users extending the DS API. Here we list a few of the methods in `DistributionStrategyExtended` class, with brief documentation. 
+
+```python
+class DistributionStrategyExtended(object):  
+  def run_steps_on_iterator(self, fn, iterator, iterations)
+    """Run `fn` with input from `iterator` for `iterations` times."""
+
+  def call_for_each_replica(self, fn, *args, **kwargs)
+    """Run `fn` once per replica with the given args."""
+
+  def unwrap(self, value): List[T]
+    """Returns the list of all per-replica values contained in `value`."""
+
+  def broadcast_to(self, value, destinations=None)
+    """Mirror a tensor on one device to given destinations (default to all worker devices).
+
+    This method can be used for custom broadcast operations than are not exposed via `ReplicaContext` or `DistributionStrategy`. For instance, one can specify the destinations to broadcast to."""
+
+  def reduce_to(self, value, aggregation, destinations)
+    """Reduces `values` to the given destinations.
+    
+    This method can be used for custom reduce operations than are not exposed via `ReplicaContext` or `DistributionStrategy`. For instance, one can specify the destinations to reduce to."""
+
+  def update(self, var, fn, *args, **kwargs)
+    """Run `fn` to update `var` using inputs mirrored to the same devices.
+      
+    Useful if doing custom updates, such as updating variables with gradients in optimizers. Otherwise, using .assign methods on the variable should be sufficient."""
+
+  def colocate_vars_with(self, colocate_with_variable):
+    """Scope that controls which devices variables will be created on.
+
+    For instance, this is used in optimizer to colocate slots with variables."""
+```
+
 
 ### Model Parallelism
 
 Model parallelism can allow the execution of models when there is insufficient
 memory on a single device (and further data parallelism is not possible).
 
-Replicator supports model partitioning, a form of model parallelism in which the
+Distribution Strategy supports model partitioning, a form of model parallelism in which the
 ops within the model are placed onto multiple devices. This is done via the
 `logical_device` context.
 
-Inputs are always located on logical device 0. Ops within the step function
-default to logical device 0 (except on TPU, which defaults to automatic
+The user can place parts of their graph on different devices by using the device scope returned by `ReplicaContext.logical_device()`. The logical devices are numbered 0 to N. Inputs are always located on logical device 0. Ops within the step function default to logical device 0 (except on TPU, which defaults to automatic
 placement).
 
 ```python
-with replicator.scope():
-  with replicator.logical_device_for_variables(1):
-    v = tf.get_variable(...)  # On logical device 1.
+with strategy.scope():
+  with strategy.logical_device_for_variables(1):
+    v = tf.Variable(...)  # On logical device 1.
     x = v * 3  # Ignores logical device context.
 
-def step(ctx, inputs):  # `inputs` on logical device 0.
+def step(inputs):  # `inputs` on logical device 0.
+  ctx = tf.distribute.get_replica_context()
   a = model_part1(inputs)  # Implicitly on logical device 0.
   with ctx.logical_device(0):
     b = model_part2(a)  # Explicitly on logical device 0.
@@ -613,24 +668,32 @@ def step(ctx, inputs):  # `inputs` on logical device 0.
     return model_part3(b)  # Explicitly on logical device 1.
 ```
 
-### Eager mode support
+### Eager Execution Support
 
-Eager mode support mostly drops out of building atop of `DistributionStrategy`.
+`DistributionStrategy` already supports eager mode and all the API changes proposed here will continue to do so.
 The entire API is designed to be eager compatible. We've called out the
 difference in behavior in eager and graph mode in the specific API
-documentations. In general, in graph mode, many of the APIs return ops which
-should be later executed with `session.run`, and in eager mode, they simply run
+documentations. In general, in graph execution mode, many of the APIs return ops which
+should be later executed with `session.run`, and when eager execution is enabled, they simply run
 the ops.
+There is a method to update session config based on the strategy (`update_session_config`) - the behavior/signature of this method might need some update based on what mechanism is available in 2.0 to update the underlying sessions when not exposed to the user. 
+As mentioned before, `run` method may run `fn` multiple times, for example in `MirroredStrategy` - once for each replica. In eager execution, multiple invocations of `fn` will run in concurrently running threads (the first invocation will happen sequentially though to allow variable creation to happen non concurrently). In graph mode, we typically expect users to call `run` only once for each `fn` to create the replicated op, and so `run` always runs `fn` in sequence for each replica.
+
+
+### Estimator vs Distribution Strategy
+At first glance it might appear that the Distribution Strategy API is similar to Estimator in some ways. For instance, for creating the replicated computation (`run`) we pass an `fn` which could look similar to Estimator’s `model_fn`. They both support `input_fn` as well. Despite these superficial similarities, Estimator and DS serve very different purposes. Estimator is a high level training framework which encapsulates a number of components - defining the model, handling input, providing hooks, running the training loop, checkpointing etc. DS API, on the other hand, is a lower level API that is used to distribute your model computation once it has been unbundled from the training loop.
+
 
 ## Usage Examples
 
-### Building a Replicator object
+### Building a `DistributionStrategy` object
 
-The first step is to build a `Replicator` instance for the chosen platform:
+The first step is to build a `DistributionStrategy` instance for the chosen platform, and :
 
 ```python
-dist_strat = ...  # Create `DistributionStrategy` for a specific regime.
-replicator = tf.replicator.Replicator(dist_strat)
+# Create `DistributionStrategy` for multi-GPU.
+strategy = tf.distribute.MirroredStrategy(...)
+session_config = strategy.update_session_config()
 ```
 
 ### Simple Classification
@@ -640,7 +703,7 @@ Below is a simple usage example for an image classification use case.
 #### Training
 
 ```python
-with replicator.scope():
+with strategy.scope():
   model = resnet.ResNetV1(resnet.BLOCKS_50)
   optimizer = tf.train.MomentumOptimizer(learning_rate, 0.9)
 
@@ -648,8 +711,7 @@ def input_fn(ctx):
   assert effective_batch_size % ctx.num_replicas_in_sync == 0
   return imagenet.ImageNet(effective_batch_size // ctx.num_replicas_in_sync)
 
-def step_fn(ctx, inputs):
-  del ctx  # Unused.
+def step_fn(inputs):
   image, label = inputs
   logits = model(images)
   cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
@@ -659,21 +721,22 @@ def step_fn(ctx, inputs):
   with tf.control_dependencies([train_op]):
     return tf.identity(loss)
 
-inputs = replicator.prepare_input(input_fn)
-per_replica_losses = replicator.run(step_fn, inputs)
-mean_loss = tf.reduce_mean(tf.stack(per_replica_losses))
+input_iterator = strategy.make_input_iterator(input_fn)
+per_replica_losses = strategy.run(step_fn, input_iterator)
+mean_loss = strategy.reduce(per_replica_losses)
 
-with tf.Session() as session:
-  session.run(replicator.initialize())
-  for _ in xrange(num_train_steps):
+with tf.Session(config=session_config) as session:
+  session.run(strategy.initialize())
+  session.run(input_iterator.initialize())
+  for _ in range(num_train_steps):
     loss = session.run(mean_loss)
-  session.run(replicator.finalize())
+  session.run(strategy.finalize())
 ```
 
 #### Evaluation
 
 ```python
-with replicator.scope():
+with strategy.scope():
   model = resnet.ResNetV1(resnet.BLOCKS_50)
 
 def eval_input_fn(ctx):
@@ -681,8 +744,7 @@ def eval_input_fn(ctx):
   return imagenet.ImageNet(
       eval_batch_size, subset="valid", shuffle=False, num_epochs=1)
 
-def eval_top1_accuracy(ctx, inputs):
-  del ctx  # Unused.
+def eval_top1_accuracy(inputs):
   image, label = inputs
   logits = model(images)
   predicted_label = tf.argmax(logits, axis=1)
@@ -690,13 +752,13 @@ def eval_top1_accuracy(ctx, inputs):
       tf.cast(tf.equal(predicted_label, label), tf.float32))
   return top1_acc
 
-eval_inputs = replicator.prepare_input(
+eval_input_iterator = strategy.make_input_iterator(
     eval_input_fn, replication_mode=InputReplicationMode.SINGLE)
-per_replica_top1_accs = replicator.run(eval_top1_accuracy, eval_inputs)
-mean_top1_acc = tf.reduce_mean(tf.stack(per_replica_top1_accs))
+per_replica_top1_accs = strategy.run(eval_top1_accuracy, eval_input_iterator)
+mean_top1_acc = strategy.reduce(per_replica_top1_accs)
 
-with tf.Session() as session:
-  session.run(replicator.initialize())
+with tf.Session(config=session_config) as session:
+  session.run(strategy.initialize())
   while True:
     while not has_new_checkpoint():
       sleep(60)
@@ -704,14 +766,14 @@ with tf.Session() as session:
     load_checkpoint()
 
     # Do a sweep over the entire validation set.
-    session.run(eval_inputs.reinitialize())
+    session.run(eval_input_iterator.initialize())
     while True:
       try:
         top1_acc = session.run(mean_top1_acc)
         ...
       except tf.errors.OutOfRangeError:
         break
-  session.run(replicator.finalize())
+  session.run(strategy.finalize())
 ```
 
 #### Sharded Input Pipeline
@@ -750,15 +812,14 @@ def input_fn(ctx):
   ds = cifar.Cifar10(batch_size)
   return ds.map(lambda x: (x['image'], sample_noise(batch_size)))
 
-with replicator.scope():
+with strategy.scope():
   discriminator = GoodfellowDiscriminator(DefaultDiscriminator2D())
   generator = DefaultGenerator2D()
   gan = GAN(discriminator, generator)
   disc_optimizer = tf.train.AdamOptimizer(disc_learning_rate, beta1=0.5, beta2=0.9)
   gen_optimizer = tf.train.AdamOptimizer(gen_learning_rate, beta1=0.5, beta2=0.9)
 
-def discriminator_step(ctx, inputs):
-  del ctx  # Unused.
+def discriminator_step(inputs):
   image, noise = inputs
   gan_output = gan.connect(image, noise)
   disc_loss, disc_vars = gan_output.discriminator_loss_and_vars()
@@ -767,8 +828,7 @@ def discriminator_step(ctx, inputs):
   with tf.control_dependencies([disc_train_op]):
     return tf.identity(disc_loss)
 
-def generator_step(ctx, inputs):
-  del ctx  # Unused.
+def generator_step(inputs):
   image, noise = inputs
   gan_output = gan.connect(image, noise)
   gen_loss, gen_vars = gan_output.generator_loss_and_vars()
@@ -777,32 +837,33 @@ def generator_step(ctx, inputs):
   with tf.control_dependencies([gen_train_op]):
     return tf.identity(gen_loss)
 
-inputs = replicator.prepare_input(input_fn)
-per_replica_disc_losses = replicator.run(discriminator_step, inputs)
-per_replica_gen_losses = replicator.run(generator_step, inputs)
-mean_disc_loss = tf.reduce_mean(tf.stack(per_replica_disc_losses))
-mean_gen_loss = tf.reduce_mean(tf.stack(per_replica_gen_losses))
+input_iterator = strategy.make_input_iterator(input_fn)
+per_replica_disc_losses = strategy.run(discriminator_step, input_iterator)
+per_replica_gen_losses = strategy.run(generator_step, input_iterator)
+mean_disc_loss = strategy.reduce(per_replica_disc_losses)
+mean_gen_loss = strategy.reduce(per_replica_gen_losses)
 
 with tf.Session() as session:
-  session.run(replicator.initialize())
-  for _ in xrange(num_train_steps):
-    for _ in xrange(num_disc_steps):
+  session.run(strategy.initialize())
+  session.run(input_iterator.initialize())
+  for _ in range(num_train_steps):
+    for _ in range(num_disc_steps):
       disc_loss = session.run(mean_disc_loss)
-    for _ in xrange(num_gen_steps):
+    for _ in range(num_gen_steps):
       gen_loss = session.run(mean_gen_loss)
-  session.run(replicator.finalize())
+  session.run(strategy.finalize())
 ```
 
 ### Reinforcement Learning
 
 This is an example of
 [IMPALA](https://deepmind.com/blog/impala-scalable-distributed-deeprl-dmlab-30/)-like
-Reinforcement Learning system, converted to eager mode.
+Reinforcement Learning system, converted to eager style.
 
 ```python
 tf.enable_eager_execution()
 
-with replicator.scope():
+with strategy.scope():
   agent = Agent(num_actions, hidden_size, entropy_cost, baseline_cost)
   optimizer = tf.train.RMSPropOptimizer(learning_rate)
 
@@ -815,52 +876,52 @@ def learner_input(ctx):
   queues.append(queue)
 
   def dequeue_batch():
-    batch = [Transition(*queue.dequeue()) for _ in xrange(batch_size_per_replica)]
+    batch = [Transition(*queue.dequeue()) for _ in range(batch_size_per_replica)]
     # Stack the `Tensor` nests along axis 1.
     return tf.nest.map_structure(lambda *xs: tf.stack(xs, axis=1), *batch)
   return dequeue_batch
 
-def learner_step(ctx, trajectories):
-  del ctx  # Unused.
+def learner_step(trajectories):
   loss = tf.reduce_sum(agent.compute_loss(trajectories))
   agent_vars = agent.get_all_variables()
   optimizer.minimize(loss, var_list=agent_vars)
   return loss, agent_vars
 
 # Create learner inputs.
-learner_inputs = replicator.prepare_input(learner_input)
+learner_inputs = strategy.make_input_iterator(learner_input)
 
 def run_actor(actor_id):
   queue = queues[actor_id % len(queues)]
-  for _ in xrange(num_trajectories_per_actor):
+  for _ in range(num_trajectories_per_actor):
     observation = get_observation_from_environment()
     action_taken, logits = agent(tf.expand_dims(observation, axis=0))
     trajectory = Transition(observation, action_taken, logits)
     queue.enqueue(tf.nest.flatten(trajectory))
 
 # Start the actors.
-for actor_id in xrange(num_actors):
+for actor_id in range(num_actors):
   threading.Thread(target=run_actor, args=(actor_id,)).start()
 
 # Run the learner.
-replicator.initialize()
+strategy.initialize()
 
-for _ in xrange(num_train_steps):
-  per_replica_outputs = replicator.run(learner_step, learner_inputs)
+for _ in range(num_train_steps):
+  per_replica_outputs = strategy.run(learner_step, learner_inputs)
   per_replica_losses, updated_agent_var_copies = zip(*per_replica_outputs)
-  mean_loss = tf.reduce_mean(tf.stack(per_replica_losses))
+  mean_loss = strategy.reduce(per_replica_losses)
 
-replicator.finalize()
+strategy.finalize()
 ```
 
 ### Global Batch Normalization
 
-When using a standard batch normalization layer with Replicator, the calculated
+When using a standard batch normalization layer with DistributionStrategy, the calculated
 mean and variance will be with-respect-to the local batch. A global batch
 normalization layer could be built using the `all_sum` method.
 
 ```python
-def global_batch_norm(ctx, x):
+def global_batch_norm(x):
+  ctx = tf.distribute.get_replica_context()
   local_x_mean = tf.reduce_mean(x, axis=0)
   local_x_squared_mean = tf.reduce_mean(tf.square(x), axis=0)
   global_x_mean, global_x_squared_mean = (
@@ -873,45 +934,28 @@ def global_batch_norm(ctx, x):
 
 ## Alternatives Considered
 
-### Using the `DistributionStrategy` API directly
+### Adding a separate `Replicator` or `Distributor` class
 
-The low-level `DistributionStrategy` API has converged quite strongly towards
-the Replicator API is several places. However, we feel there are sufficient
-areas in which exposing researchers directly to the `DistributionStrategy` API
-is undesirable to justify a level of abstraction above it. The
-`DistributionStrategy` API is designed for flexibility and is used in a lot of
-TensorFlow components internally. It has evolved to be quite an extensive API
-and it would be impractical to expect most ML users to use the API directly. It
-would require them to figure out which methods are useful for them and which are
-not, and be more error-prone.
+This would implement a wrapper API on top of the low-level
+DistributionStrategy and expose just the core methods. Based on feedback, we decided another entry-point to
+the API would be confusing. Given the overlap between Replicator and Distribution
+Strategy, we can instead merge them while exposing low-level functionality
+through an `extended` property as described above.
 
-Replicator provides a narrow and simpler API on top of Distribution Strategy
+### Exposing all the methods of `DistributionStrategy` API directly
+
+The `DistributionStrategy` API is designed for flexibility and is used in a lot of
+TensorFlow components internally. It has evolved to be quite an extensive API and hence we think it would be less cognitive overhead for users if only the most commonly used methods are exposed in the main class, and less commonly used methods are still available  in another class. This allows us to 
+provide a narrow and simpler API
 that should be sufficient for most use cases. It has been tested internally with
 a significant number of researchers in Alphabet which gives us this confidence.
-It also allows users to do things in fewer API calls than Distribution Strategy.
-
-### Multiple `Replicator` implementations
-
-We considered having separate implementations for different hardware
-architectures (`MultiGpuReplicator`, `TpuReplicator`, etc.). It was decided to
-instead create a single implementation which takes a `DistributionStrategy`
-instance.
-
-### `num_steps_per_run` parameter
-
-We considered including a `num_steps_per_run` parameter on the `run` method
-which would run multiple steps for every call to `run`. This can give better
-performance as it amortizes some of the communication overheads. We don't
-believe this is necessary, as users should be able to recover any performance
-losses from its omission by wrapping the call to `run` in a `tf.while_loop`.
 
 ### Stacking `run` outputs
 
-One option is that `replicator.run` returns a nest of stacked tensors, with an
+One option is that `strategy.run` returns a nest of stacked tensors, with an
 additional leading dimension of size `num_replicas_in_sync`.
 
-We decided instead of stacking the per replica tensors, we will return a list of
-nests instead. This is because for large outputs (e.g. RL agent variables), in a
+We decided instead of stacking the per replica tensors, we will return a nest `PerReplica` objects instead. This is because for large outputs (e.g. RL agent variables), in a
 multi-worker configuration, stacking would force them to be copied to one of the
 hosts (host 0) which seems unnecessarily restrictive.
 
@@ -925,19 +969,19 @@ elegantly.
 
 We considered a few different names for some things.
 
-#### Unit of computation / context
+#### Unit of computation (one copy of the model)
 
 1.  replica
 1.  tower
 
-Decided "replica" based on popular opinion through a survey.
+Decided "replica" based on popular opinion through a survey. Replica more clearly conveys the concept we were trying to represent, and tower may be confused with some other meanings of tower in ML. 
 
 #### Machines
 
 1.  worker
 1.  host
 
-Replicator and Distribution Strategy previously used both. Decided on "worker"
+Distribution Strategy previously used both. Decided on "worker"
 by popular opinion. Also, using worker leaves open the possibility that we may
 have multiple hosts per worker in the case of very large models.
 
@@ -947,16 +991,32 @@ We considered "input replica" and "input shard" but none of those capture the
 variety of use cases so we agreed on "input pipeline" which doesn't necessarily
 say they're copies of each other, or are sharded.
 
-## Questions and Discussion Topics
+## Open Questions and Discussion Topics
 
-*   Should `InputReplicationMode` be called something else? `InputPipelineMode`?
-    `InputMode`? Relatedly, is `SINGLE` a good name for the case where there is
-    one input pipeline?
-*   Should this live under the distribution strategy directory
-    (tensorflow/python/distribute) or a new directory? Similarly, should the API
-    be in `tf.distribute` namespace or a new namespace (`tf.replicate`)?
+### API questions
+*   Should `DistributionStrategy.run` be allowed to return non tensor outputs? This might be useful (at least in graph execution) to return relevant objects defined in step `fn`, for instance a metric object. If this is not allowed, the user has to restructure their code to capture any non tensor outputs defined inside `fn` if they want to access them outside. 
+*   Should DS handle calling initializer for the input dataset or leave it up to the user? (Current design leaves it up to the user)
+*   Should we allow passing arbitrary args/kwargs in `run` which will then be passed to `fn`? Will make it more handy than having to capture anything that might be needed. If we do allow this, what’s a good way to handle any future name collisions with user’s kw?
+*   Should `DistributionStrategy.run` return a `List` of outputs from each `fn` call instead of a `PerReplica/Mirrored` type values which preserve some of the replica information? 
+*   Should InputReplicationMode be specified in the DistributionStrategy constructor and not allowed to be changed for different inputs (create a new strategy if you need a different input replication mode). Current design passes InputReplicationMode in `make_input_iterator` method so it can be changed for different inputs. This question is also related to how much state does the DS object contain, especially in multi worker modes etc. 
+*   Should we have separate methods for each type of reduce/all_reduce operation (all_sum, all_mean etc), or one common method with an enum specifying which AggregationType (SUM, MEAN etc)?
+*   Should `ReplicaContext` be passed into the `fn` in `run`, or being accessible from a module method is better? 
 *   Certain distribution strategies are between-graph
     (CollectiveAllReduceStrategy and ParameterServerStrategy). In those cases,
-    should the `Replicator.run` method return outputs only from the replicas in
+    should the `DistributionStrategy.run` method return outputs only from the replicas in
     that graph? Or should we try to return outputs from all graphs? Do we need
     to add more properties like “num_replicas_in_graph” ?
+
+
+### Naming questions
+*   What should the `extended` property and class be called? “Advanced” is the other strong contender. Some other candidates we discussed: internal, complex, expert, framework, platform, custom, extra, extras, core, supplementary, additional, auxiliary, special, secondary, specialized, all, full, complete, extended, detail.
+*   Alternate names for `InputReplicationMode`? `InputPipelineMode`? `InputMode`? Relatedly, is `SINGLE` a good name for the case where there is one input pipeline? We can call it `NONE` but that doesn’t work as an `InputPipelineMode` or `InputMode`.
+
+### Other questions:
+*   How would we handle configuring the session options according to the strategy in eager execution?
+*   Can we keep type annotations in code for documentation purposes (but turn off type checking)? 
+*   ([From Karmel’s comment](https://github.com/tensorflow/community/pull/25#discussion_r228659379)) Keras supports DistStrat natively, but we have also discussed the fact that the inclusion of DistStrat in compile/fit limits our ability to handle, say, model parallelism or very large models. Is there an intersection of Keras and DS API that allows for model parallelism/more complicated use semantics without requiring too much from the Keras user?
+
+
+
+

--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -8,7 +8,7 @@
 
 ## Objective
 
-We propose to add a new API in TensorFlow for replicating computation across
+This document presents a proposal to add a new API in TensorFlow for replicating computation across
 different GPUs, TPUs and multiple machines. It will be implemented as a thin
 usability API layer on top of
 [DistributionStrategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy).

--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -2,10 +2,9 @@
 
 | Status        | Proposed                                                |
 | :------------ | :------------------------------------------------------ |
-| **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, |
-:               : petebu@google.com, priyag@google.com                    :
+| **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, petebu@google.com, priyag@google.com |
 | **Sponsor**   | joshl@google.com                                        |
-| **Updated**   | 2018-10-16                                              |
+| **Updated**   | 2018-10-17                                              |
 
 ## Objective
 

--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -363,7 +363,7 @@ An instance of the `ReplicaContext` can be retrieved by calling `tf.distribute.g
 
 ```python
 class ReplicaContext(object):
-  “””A context within replicated computation.
+  """A context within replicated computation.
 
   IMPORTANT: The ordering of calls to cross-replica interactions must be identical in all replicas.
   This includes `merge_call` and all communications methods (`all_sum`, etc.). Where possible, an exception
@@ -371,24 +371,18 @@ class ReplicaContext(object):
   Particular care should be taken when iterating over Python dictionaries.
 
   Example of incorrect usage:
-  ```
   losses = {"loss1": ..., "loss2": ...}
   total_losses = {k: ctx.all_sum(v) for k, v in losses.iteritems()}
-  ```
 
   In Python versions earlier than 3.7, iteration order of dictionaries is not guaranteed.
   Use an `OrderedDict`:
-  ```
   losses = collections.OrderedDict([("loss1", ...), ("loss2", ...)])
   total_losses = {k: ctx.all_sum(v) for k, v in losses.iteritems()}
-  ```
 
   However, in this particular example, the dictionary keys are sortable. In such cases, this is best:
-  ```
   losses = {"loss1": ..., "loss2": ...}
   total_losses = ctx.all_sum(losses)
-  ```
-  “””
+  """
 
   @property
   def replica_id(self) -> tf.Tensor:

--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -1,6 +1,6 @@
 # Distribution Strategy - Revised API
 
-| Status        | Proposed                                                                  |
+| Status        | Accepted                                                                  |
 | :------------ | :------------------------------------------------------------------------ |
 | **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, joshl@google.com, |
 |               | petebu@google.com, priyag@google.com, tomhennigan@google.com              |

--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -930,7 +930,7 @@ We considered a few different names for some things.
 1.  replica
 1.  tower
 
-Decided "replica" based on popular opinion (through a survey).
+Decided "replica" based on popular opinion through a survey.
 
 #### Machines
 

--- a/rfcs/20181016-replicator.md
+++ b/rfcs/20181016-replicator.md
@@ -5,7 +5,7 @@
 | **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, joshl@google.com, |
 |               | petebu@google.com, priyag@google.com, tomhennigan@google.com              |
 | **Sponsor**   | wicke@google.com                                                          |
-| **Updated**   | 2018-10-31                                                                |
+| **Updated**   | 2018-11-08                                                                |
 
 ## Objective
 


### PR DESCRIPTION
Review period closes 2018-11-08

# Distribution Strategy - Revised API

| Status        | Proposed                                                                  |
| :------------ | :------------------------------------------------------------------------ |
| **Author(s)** | cjfj@google.com, dominikg@google.com, jhseu@google.com, joshl@google.com, |
|               | petebu@google.com, priyag@google.com, tomhennigan@google.com              |
| **Sponsor**   | wicke@google.com                                                          |
| **Updated**   | 2018-11-12                                                                |

## Objective

This document presents a proposal to seek feedback on a revised [Distribution Strategy](https://www.tensorflow.org/api_docs/python/tf/contrib/distribute/DistributionStrategy) API and illustrate its usage in various situations. Distribution Strategy aims to allow users to easily distribute their computation across 
different GPUs, TPUs and multiple machines. Until now, the recommended usage of Distribution Strategy has been through TensorFlow high level training frameworks such as [`tf.keras`](https://www.tensorflow.org/guide/keras) and [`Estimator`](https://www.tensorflow.org/guide/estimators). In this proposal, we want to show how one can use Distribution Strategy APIs directly for distributing custom training loops, and get feedback on those APIs. This use case is important for many users who want more control of their training loops, such as ML researchers. We have tested a similar version of this API internally with many researchers in Alphabet and the current proposal is based on their feedback.

This is also an opportune time to get public feedback as we are in the process of migrating Distribution Strategy APIs from `tf.contrib` to core TensorFlow (as part of TF 2.0). As part of the move, we want to improve and reorganize the APIs to make them more user friendly and understandable.


