### PR TITLE
Add SIG IO release process and release team

### DIFF
--- a/sigs/io/CHARTER.md
+++ b/sigs/io/CHARTER.md
@@ -20,13 +20,17 @@ Archives of the mailing list are publicly accessible.
 
 * SIG IO  mailing list: [io@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/io)
 * Repository: [github.com/tensorflow/io](https://github.com/tensorflow/io)
+* Python Package Repository: [tensorflow-io](https://pypi.org/project/tensorflow-io)
+
+## Releases
+
+Information about SIG IO releases and the release team could be found in [RELEASE.md](RELEASE.md).
 
 ## Contacts
 
-* Project leads: Yong Tang [@yongtang](https://github.com/yongtang) -
-  yong.tang.github@outlook.com, Anthony Dmitriev
-  [@dmitrievanthony](https://github.com/dmitrievanthony) -
-  dmitrievanthony@gmail.com
+* Project leads:
+  - Yong Tang [@yongtang](https://github.com/yongtang) - yong.tang.github@outlook.com
+  - Anthony Dmitriev [@dmitrievanthony](https://github.com/dmitrievanthony) - dmitrievanthony@gmail.com
 * TensorFlow technical contact [@mrry](https://github.com/mrry) - mrry@google.com
 * For administrative questions, contact Edd Wilder-James
   [@ewilderj](https://github.com/ewilderj) - ewj at google

--- a/sigs/io/RELEASE.md
+++ b/sigs/io/RELEASE.md
@@ -1,0 +1,42 @@
+# SIG IO Releases
+
+At the moment SIG IO Releases consist of two parts:
+- Release of source code with versioning in GitHub
+- Release of python package in PyPI
+
+## GitHub Source Code Release
+
+To perform a release in GitHub, the following steps are needed:
+- Create a PR to update the RELEASE.md in
+  [github.com/tensorflow/io](https://github.com/tensorflow/io)
+  * Add updates for new features, enhancements, bug fixes
+  * Add contributors using `git shortlog <last-version>..HEAD -s`
+- Merge the PR for RELEASE.md update
+- Create a new version through GitHub
+
+## PyPI Python Package Release
+
+To perform a release in PyPI, first complete the above GitHub release, then
+build pip packages locally with docker in the following commands
+```
+$ docker run -it -v ${PWD}:/working_dir -w /working_dir \
+    tensorflow/tensorflow:custom-op bash -x /working_dir/release.sh <2.7|3.4|3.5|3.6>
+```
+Note the above commands has to run four times with 2.7, 3.4, 3.5, 3.6
+to generate all pip packages for different python versions.
+
+Then upload `artifacts/*.whl` files with:
+```
+twine upload artifacts/*
+```
+
+## SIG IO Release Team
+
+Everybody with an interest in helping SIG IO releases, is welcome
+to join the Release Team. To participate, create a PR to update
+the doc or send an email to SIG IO mailing list
+[io@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/io).
+Please provide both GitHub and PyPI handle to join the release team.
+
+Current Release Team:
+- Yong Tang - GitHub: [@yongtang](https://github.com/yongtang) - PyPI: [yongtang](https://pypi.org/user/yongtang)


### PR DESCRIPTION
This fix update the SIG IO's release process so that
anyone could help the release for SIG IO.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>