### PR TITLE
Add Anthony to the Release team of sig-io

### DIFF
--- a/sigs/io/RELEASE.md
+++ b/sigs/io/RELEASE.md
@@ -40,4 +40,5 @@ Please provide both GitHub and PyPI handle to join the release team.
 
 Current Release Team:
 - Yong Tang - GitHub: [@yongtang](https://github.com/yongtang) - PyPI: [yongtang](https://pypi.org/user/yongtang)
+- Anthony Dmitriev - GitHub: [@dmitrievanthony](https://github.com/dmitrievanthony) - PyPI: [dmitrievanthony](https://pypi.org/user/dmitrievanthony)
 - Yuan (Terry) Tang - GitHub: [@terrytangyuan](https://github.com/terrytangyuan) - PyPI: [terrytangyuan](https://pypi.org/user/terrytangyuan)


### PR DESCRIPTION
This PR adds Anthony to the Release team of sig-io with his PyPI.org.

/cc @dmitrievanthony @ewilderj 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>