### PR TITLE
Add Bryan to SIG-IO release team

### DIFF
--- a/sigs/io/RELEASE.md
+++ b/sigs/io/RELEASE.md
@@ -70,3 +70,4 @@ Current Release Team:
 - Yong Tang - GitHub: [@yongtang](https://github.com/yongtang) - PyPI: [yongtang](https://pypi.org/user/yongtang)
 - Anthony Dmitriev - GitHub: [@dmitrievanthony](https://github.com/dmitrievanthony) - PyPI: [dmitrievanthony](https://pypi.org/user/dmitrievanthony)
 - Yuan (Terry) Tang - GitHub: [@terrytangyuan](https://github.com/terrytangyuan) - PyPI: [terrytangyuan](https://pypi.org/user/terrytangyuan)
+- Bryan Cutler - GitHub: [@BryanCutler](https://github.com/BryanCutler) - PyPI: [cutlerb](https://pypi.org/user/cutlerb)


### PR DESCRIPTION
This change adds Bryan to the SIG-IO release team with GitHub and PyPi handles.