### PR TITLE
Update 20181016-optimizer-unification.md

### DIFF
--- a/rfcs/20181016-optimizer-unification.md
+++ b/rfcs/20181016-optimizer-unification.md
@@ -313,13 +313,13 @@ FtrlOptimizer(learning_rate,
 Proposed signature:
 
 ```Python
-FTRL(learning_rate,
+FTRL(learning_rate=learning_rate,
      learning_rate_power=-0.5,
      initial_accumulator_value=0.1,
      l1_regularization_strength=0.0,
      l2_regularization_strength=0.0,
-     name="FTRL",
-     l2_shrinkage_regularization_strength=0.0)
+     l2_shrinkage_regularization_strength=0.0,
+     name="FTRL")
 ```
 
 


### PR DESCRIPTION
fix `FTRL` for using `learning_rate`  as keyword arguments, and move `name` to last param.  