### PR TITLE
RFC: Keras SavedModel saving/loading

### DIFF
--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -1,10 +1,10 @@
 # Keras SavedModel saving/loading 
 
-| Status        | Proposed                                             |
+| Status        | Accepted                                             |
 :-------------- |:---------------------------------------------------- |
 | **Author(s)** | Kathy Wu (kathywu@google.com)                        |
 | **Sponsor**   | Karmel (karmel@google.com)                           |
-| **Updated**   | 2019-05-21                                           |
+| **Updated**   | 2019-05-30                                           |
 
 ## Objective
 

--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -166,27 +166,27 @@ Only Tensorflow checkpointable objects and functions can be serialized to SavedM
 
 The following checkpointable objects and functions are attached to the saved Keras model:
 
-- `variables`: List of all variables in this layer and submodules.
-- `trainable_variables`: List of all trainable variables in this layer and submodules.
-- `non_trainable_variables`: List of all non-trainable variables in this layer and submodules.
+- `variables`: List of all variables in this layer and sublayers.
+- `trainable_variables`: List of all trainable variables in this layer and sublayers.
+- `non_trainable_variables`: List of all non-trainable variables in this layer and sublayers.
 - `regularization_losses`: List of unconditional loss functions in this layer 
-  and submodules. Each function takes no arguments, and returns a scalar 
+  and sublayers. Each function takes no arguments, and returns a scalar 
   tensor. 
-- `submodules`: Flat list of all sublayers (does not include metrics, even though Metric subclasses Layer).
+- `layers`: Flat list of all sublayers (does not include metrics, even though Metric subclasses Layer).
 - `metrics`: List of all metric layers attached to this layer and sublayers.
 - `_variables`: List of all variables owned by this object (and not sublayers)
 - `__call__`: Returns the outputs of the call function.
 - `call_and_return_conditional_losses`: Returns the outputs of the call function, as well as a list input-dependent losses (does not include the activity regularizer loss).
 - `call_and_return_all_conditional_losses`: A function that calls the model and returns returns outputs and returns all input-dependent losses. Unlike `call_and_return_conditional_losses`, the losses returned in this function includes the activity regularizer and any compiled losses.
 - `activity_regularizer_fn`: Activity regularization function
-- `compile_loss_functions`: List of loss functions added during `model.compile`.
+- `compile_losses`: List of loss functions added during `model.compile`.
 - `compile_metrics`: List of metric objects added during `model.compile`.
 
 The optimizer is a checkpointable object, so it is automatically saved to the SavedModel.
 
 **Public vs private variables (variables vs _variables)**
 
-The public attributes are exported so that the all variables/trainable variables/etc. may be accessed without the Keras python logic to recursively traverse all the submodules. The private variable attribute is exported so that when the model is deserialized:
+The public attributes are exported so that the all variables/trainable variables/etc. may be accessed without the Keras python logic to recursively traverse all the sublayers. The private variable attribute is exported so that when the model is deserialized:
 1. it is clear which objects own variables
 2. variables are guaranteed to be in the same order. This is important for Keras models, which uses layer and weight order for certain operations (e.g. saving/loading to HDF5).
 

--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -29,6 +29,7 @@ be saved/loaded without having the original code (currently required by the HDF5
 
 - Serializing custom training loops. Only the standard `model.compile` to 
   `model.fit` use case is covered.
+- Changing existing serialization formats
 
 ## Motivation
 
@@ -218,6 +219,8 @@ When reconstructing a Keras model, the saved attributes are remapped to the orig
 
 1. Do we all agree on the API changes?
 2. Are there other aspects of the model that should be serialized/deserialized?
+3. Should `tf.saved_model.load` return a generic object or Keras model?
+4. Syncing common endpoints with tf.module
 
 
 

--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -4,7 +4,7 @@
 :-------------- |:---------------------------------------------------- |
 | **Author(s)** | Kathy Wu (kathywu@google.com)                        |
 | **Sponsor**   | Karmel (karmel@google.com)                           |
-| **Updated**   | 2019-05-09                                           |
+| **Updated**   | 2019-05-21                                           |
 
 ## Objective
 

--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -27,8 +27,7 @@ be saved/loaded without having the original code (currently required by the HDF5
 
 **Non-goals:**
 
-- Serializing custom training loops. Only the standard `model.compile` to 
-  `model.fit` use case is covered.
+- Serializing custom training loops. Only the standard `model.compile` to `model.fit` use case is covered. Custom training loops may still be saved by wrapping it in a tf.function, and passing it to the `signatures` argument or setting it as an attribute of the model (e.g. model.train_loop = ...). 
 - Changing existing serialization formats
 
 ## Motivation

--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -214,6 +214,9 @@ GenericObject obj → .variables, .trainable_variables, etc.
 
 When reconstructing a Keras model, the saved attributes are remapped to the original names. The exception is the call function, which uses `call_and_return_conditional_losses` instead of `__call__`.
 
+### Compatibility Guarantees
+Keras SavedModels are backward and forward compatible across minor TensorFlow versions. Therefore, checkpointable object and tf.function attributes are not removed from the SavedModel. New attributes may be added if additional serialization is requested.
+
 ## Questions and Discussion Topics
 
 1. Do we all agree on the API changes?

--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -53,6 +53,7 @@ Related works:
   ```
   model.save(path, include_optimizer=None, save_format=None, signatures=None)
   ```
+  - include_optimizer: (for SavedModel format) Whether or not the SavedModel should contain the optimizer. Note that even if this argument is `False`, any compiled losses and metrics are saved, since they are separate from the optimizer.
   - save_format: Either `h5` or `tf`. Specifies the format for saving the
     model. If left as None, the save format will default to tf unless the 
     path ends with `.h5`, `.hdf5`, or `.keras`.
@@ -67,8 +68,7 @@ Related works:
   modified to automatically detect SavedModels. In both cases, a Keras model 
   object is returned. The root object in the SavedModel must at least contain
   [shared endpoints](#shared-endpoints), otherwise, an error is raised. 
-- `tf.saved_model.save` and `tf.keras.models.save_model` and `model.save`: 
-  additional dependencies/functions are serialized to the SavedModel. See
+- `tf.saved_model.save` and `tf.keras.models.save_model` and `model.save`: These functions have consistent saving results. Additional dependencies/functions are serialized to the SavedModel. See
   [Serialization coverage](#serialization-coverage)
 
 **Note**
@@ -125,6 +125,8 @@ And later, loading the SavedModel:
 model = tf.keras.load_model('/tmp/keras_model')
 model.signatures  #  {'classify' → tf.function, 'predict' → tf.function} 
 ```
+
+If the `signatures` argument is left empty, then a default signature is created with the traced model call function. In the future, we may consider always exporting the default signature (even if the `signatures` argument is set).
 
 ### Serialization coverage
 
@@ -220,7 +222,7 @@ All losses contained in the model are split between `regularization_losses` and 
 Any SavedModel with these endpoints defined may be loaded as a Keras model using `tf.keras.models.load_model`.
 
 ### Compatibility Guarantees
-Keras SavedModels are backward and forward compatible across minor TensorFlow versions. Therefore, checkpointable object and tf.function attributes will not be removed from the SavedModel. New attributes can be added if additional serialization is requested.
+Keras SavedModels are backward and forward compatible across minor TensorFlow versions (similar to [GraphDef](https://www.tensorflow.org/alpha/guide/version_compat)). Therefore, checkpointable object and tf.function attributes will not be removed from the SavedModel. New attributes can be added if additional serialization is requested. 
 
 ## Questions and Discussion Topics
 
@@ -233,5 +235,3 @@ Keras SavedModels are backward and forward compatible across minor TensorFlow ve
    **Generic object**
 4. Syncing common endpoints with tf.module
    tf.module is extremely open-ended, so just the `.variables` attribute should be synced between tf.module SavedModel and Keras SavedModel. Note about `.trainable_variables` -- Keras layers and tf.modules have different definitions of trainable variables.
-
-

--- a/rfcs/20190509-keras-saved-model.md
+++ b/rfcs/20190509-keras-saved-model.md
@@ -215,7 +215,7 @@ GenericObject obj → .variables, .trainable_variables, etc.
 When reconstructing a Keras model, the saved attributes are remapped to the original names. The exception is the call function, which uses `call_and_return_conditional_losses` instead of `__call__`.
 
 ### Compatibility Guarantees
-Keras SavedModels are backward and forward compatible across minor TensorFlow versions. Therefore, checkpointable object and tf.function attributes are not removed from the SavedModel. New attributes may be added if additional serialization is requested.
+Keras SavedModels are backward and forward compatible across minor TensorFlow versions. Therefore, checkpointable object and tf.function attributes will not be removed from the SavedModel. New attributes can be added if additional serialization is requested.
 
 ## Questions and Discussion Topics
 


### PR DESCRIPTION
**Feedback period open until 2019-05-27**

# Keras SavedModel saving/loading 

 | Status        | Accepted                                             |
:-------------- |:---------------------------------------------------- |
| **Author(s)** | Kathy Wu (kathywu@google.com)                        |
| **Sponsor**   | Karmel (karmel@google.com)                           |
| **Updated**   | 2019-05-30                                           |

 ## Objective

 Add ability to (1) save a [TensorFlow SavedModel](https://www.tensorflow.org/alpha/guide/saved_model) from a Keras model and (2) load a Keras model from a SavedModel. This is a  standalone serialization format, which allows models with custom objects to be saved/loaded without having the original code (currently required by the HDF5 and JSON formats). 

 **Goals:**

 - Add SavedModel format for saving Keras models. 
- Support comprehensive model serialization/deserialization 
  - Define model serialization coverage (what parts of the model are saved to the SavedModel) 
  - Address serialization pattern that is reusable across different frameworks (TensorFlow Hub, tf.module, etc.) 
  - Define SavedModel deserialization (properties of the reconstructed model) 

 **Non-goals:**

 - Serializing custom training loops. Only the standard `model.compile` to  `model.fit` use case is covered.
- Changing existing serialization formats