### PR TITLE
Add way to allocate numbers to RFCs

### DIFF
--- a/rfcs/yyyymmdd-rfc-template.md
+++ b/rfcs/yyyymmdd-rfc-template.md
@@ -2,6 +2,7 @@
 
 | Status        | (Proposed / Accepted / Implemented / Obsolete)       |
 :-------------- |:---------------------------------------------------- |
+| **RFC #**     | [NNN](https://github.com/tensorflow/community/pull/NNN) (update when you have community PR #)|
 | **Author(s)** | My Name (me@example.org), AN Other (you@example.org) |
 | **Sponsor**   | A N Expert (whomever@tensorflow.org)                 |
 | **Updated**   | YYYY-MM-DD                                           |


### PR DESCRIPTION
Start allocating each RFC a number, for ease of future reference, based on the pull request. This enables tracing the RFC back to its discussion in the GitHub PR. 
Further work: we can also go back and add these to pre-existing RFCs.