### PR TITLE
Update SIG I/O release team

### DIFF
--- a/sigs/io/RELEASE.md
+++ b/sigs/io/RELEASE.md
@@ -82,3 +82,4 @@ Current Release Team:
 - Anthony Dmitriev - GitHub: [@dmitrievanthony](https://github.com/dmitrievanthony) - PyPI: [dmitrievanthony](https://pypi.org/user/dmitrievanthony)
 - Yuan (Terry) Tang - GitHub: [@terrytangyuan](https://github.com/terrytangyuan) - PyPI: [terrytangyuan](https://pypi.org/user/terrytangyuan)
 - Bryan Cutler - GitHub: [@BryanCutler](https://github.com/BryanCutler) - PyPI: [cutlerb](https://pypi.org/user/cutlerb)
+- Aleksey Vlasenko - GitHub: [@vlasenkoalexey](https://github.com/vlasenkoalexey) - PyPI: [vlasenkoalexey](https://pypi.org/user/vlasenkoalexey)


### PR DESCRIPTION
Update SIG I/O release team

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>