### PR TITLE
How to become a google code in mentor #173

### DIFF
--- a/sigs/build/tensorflow-testing.md
+++ b/sigs/build/tensorflow-testing.md
@@ -37,7 +37,7 @@ If you would like to submit general feedback about TensorFlow (and in particular
 
 **Friction logs** are documents that describe the frustrations and delights of a product, focused around a specific use case (for example, creating an LSTM model for text classification). They're also intended to be brutally honest - feel free to vent or to praise! 😊
 
-An template and example of a TensorFlow friction log can be found [here](https://docs.google.com/document/d/1_-0Zzn0hqS4ltLwqWAHm41-MgE60_9zlKyPHr5c-HCs/edit?usp=sharing).
+An template and example of a TensorFlow friction log can be found [here](https://docs.google.com/document/d/1HVG3t-mgGZKU4iMeguTWGejbnQ54qUTXwdCFkA5xHG0/edit?usp=sharing).
 
 Once you have completed such a document, please email it to our [testing team](mailto:testing@tensorflow.org).
 


### PR DESCRIPTION
Thanks for the application for being a mentor in Google Code In program. We are excited to review them and welcome you to the Tensorflow community. There are new guidelines from google to select mentors based on the contribution and the trust. We can't select the mentors based on the submitted form alone. We are also reviewing the list of mentors who are already got selected.
We want to ensure that mentors
Are familiar with the codebase, did some contributions (pull requests, design documents, issue triaging etc) and the activity in the community #173 