### PR TITLE
Update dead link in charter.md

### DIFF
--- a/sigs/micro/CHARTER.md
+++ b/sigs/micro/CHARTER.md
@@ -14,7 +14,7 @@ Archives of the mailing list will be publicly available.
 
 * [SIG Micro mailing list](https://groups.google.com/a/tensorflow.org/forum/#!forum/micro)
 * [SIG Micro Gitter chat channel](https://gitter.im/tensorflow/sig-micro)
-* [TensorFlow Micro code](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/experimental/micro)
+* [TensorFlow Micro code](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/micro)
 * [SIG Micro monthly meeting notes and agenda](https://goo.gle/tf-micro-notes)
 
 ## Contacts


### PR DESCRIPTION
the micro folder was moved out of the experimental folder. this was not yet updated in the link.