### PR TITLE
Fix typo in 20190430-tokenization-conventions.md.

### DIFF
--- a/rfcs/20190430-tokenization-conventions.md
+++ b/rfcs/20190430-tokenization-conventions.md
@@ -281,9 +281,7 @@ class MyCustomTokenizer(Tokenizer):
         y=tf.expand_dims(script_tokenized.flat_values, 1),
         x=unicode_char_split.values)
 
-    # put back into [batch, (num
-
-update conventions doc -_tokens), (num_unicode_chars)]
+    # put back into [batch, (num_tokens), (num_unicode_chars)]
     mix_tokenized = tf.RaggedTensor.from_row_lengths(
         values=unicode_split_tokens, row_lengths=script_tokenized.row_lengths())
 


### PR DESCRIPTION
Seems like a copy&paste glitch broke the comment in the code block.