### PR TITLE
SIG Addons: Procedure and RFC template for Addons migrations

### DIFF
--- a/sigs/addons/MIGRATION_RFC_TEMPLATE.md
+++ b/sigs/addons/MIGRATION_RFC_TEMPLATE.md
@@ -24,7 +24,7 @@
 
 ## Changes to Implementation (If Needed)
 ```
-Code snippet showing proposed code migration
+Code snippet(s) showing proposed code changes
 ```
 * Discussion on the rationale for changes
 

--- a/sigs/addons/MIGRATION_RFC_TEMPLATE.md
+++ b/sigs/addons/MIGRATION_RFC_TEMPLATE.md
@@ -30,8 +30,8 @@ Code snippet(s) showing proposed code changes
 
 ## Transition Plan
 * Proposed landing place in tf-core
+* Will there be any changes to the API? (e.g. additional parameters or renaming)
 * Deprecation plan for Addons
-    * Will we be able to alias the core implementation? (parameters must be exact match)
 
 ## Relevant GitHub Issues
 

--- a/sigs/addons/MIGRATION_RFC_TEMPLATE.md
+++ b/sigs/addons/MIGRATION_RFC_TEMPLATE.md
@@ -1,0 +1,39 @@
+# Migrate XXXXX from TensorFlow Addons to TensorFlow Core
+
+| Status      | Proposed (Waiting for Sponsor)                                                                                           |
+| :---------- | :------------------------------------------------------------------------------------------------- |
+| **RFC #**   | TBD after PR |                                       |
+| **Authors** | XXXXXXXXXX   |
+| **Sponsor** | XXXXXXXXXX   |
+| **Updated** | YYYY-MM-DD   |
+| **Sponsorship Deadline** | YYYY-MM-DD   |
+
+
+## Background
+* Link to implementation in Addons:
+* What are the use cases for the addon?
+* Have there been signifiant issues reported to Addons that need to be adressed?
+* When was it implemented in Addons?
+* What is the pytest coverage of the addon?
+
+## Metrics Supporting the Migration
+* OSS usage, H5 Index, etc.
+
+## Transition Plan
+* Proposed landing place in tf-core
+* Deprecation plan for Addons
+    * Will we be able to alias the core implementation? (parameters must be exact match)
+
+## Changes to Implementation (If Needed)
+```
+Code snippet showing proposed code migration
+```
+* Discussion on the rationale for changes
+
+## Relevant GitHub Issues
+
+## Questions and Discussion Topics
+
+
+## Final Decision
+TBD

--- a/sigs/addons/MIGRATION_RFC_TEMPLATE.md
+++ b/sigs/addons/MIGRATION_RFC_TEMPLATE.md
@@ -6,23 +6,21 @@
 | **Authors** | XXXXXXXXXX   |
 | **Sponsor** | XXXXXXXXXX   |
 | **Updated** | YYYY-MM-DD   |
-| **Sponsorship Deadline** | YYYY-MM-DD   |
+| **Sponsorship Deadline** | YYYY-MM-DD (45 Days after submission)  |
 
-
-## Background
-* Link to implementation in Addons:
+## Rationale for Migration
 * What are the use cases for the addon?
-* Have there been signifiant issues reported to Addons that need to be adressed?
-* When was it implemented in Addons?
-* What is the pytest coverage of the addon?
-
-## Metrics Supporting the Migration
 * OSS usage, H5 Index, etc.
 
-## Transition Plan
-* Proposed landing place in tf-core
-* Deprecation plan for Addons
-    * Will we be able to alias the core implementation? (parameters must be exact match)
+## Historical Information
+* Have there been signifiant issues reported to Addons that need to be adressed?
+* When was it implemented in Addons?
+
+## Implementation Details
+* Link to implementation in Addons:
+* Does this include custom-op kernels?
+    * Are they CPU/GPU/TPU compatible?
+* What is the pytest coverage of the addon?
 
 ## Changes to Implementation (If Needed)
 ```
@@ -30,10 +28,14 @@ Code snippet showing proposed code migration
 ```
 * Discussion on the rationale for changes
 
+## Transition Plan
+* Proposed landing place in tf-core
+* Deprecation plan for Addons
+    * Will we be able to alias the core implementation? (parameters must be exact match)
+
 ## Relevant GitHub Issues
 
 ## Questions and Discussion Topics
-
 
 ## Final Decision
 TBD

--- a/sigs/addons/MIGRATION_TO_CORE.md
+++ b/sigs/addons/MIGRATION_TO_CORE.md
@@ -1,0 +1,32 @@
+# Migration From TF-Addons To TensorFlow Core
+
+### In-Progress & Previous Migrations:
+https://github.com/tensorflow/addons/projects/2/
+
+### Process 
+1. Create an issue in TensorFlow Addons for a candidate that you think should be 
+migrated. 
+2. The SIG will evaluate the request and add it to the `Potential Candidates` section 
+of our GitHub project.
+3. If it's agreed that a migration makes sense, an RFC needs to be written to discuss 
+the move with a larger community audience. 
+    * If the transition will impact tf-core and Keras then submit the RFC to 
+    [TensorFlow Community](https://github.com/tensorflow/community)
+    * Additions which only subclass Keras APIs should submit their migration proposals to 
+    [Keras Governance](https://github.com/keras-team/governance)
+    
+4. A sponsor from the TF/Keras team must agree to shepard the transition.
+   * If no sponsor is obtained after 45 days the RFC will be rejected and will remain 
+   as part of Addons.
+5. If a sponsor is obtained, and the RFC is approved, a pull request must move the 
+addon along with proper tests.
+6. After merging, the addition will be replaced with an alias to the core function 
+if possible. If an alias is not possible (e.g. large parameter changes), then a deprecation 
+warning will be added and will be removed from TFA after 2 releases. 
+
+
+### Criteria for Migration
+* The addition is widely used throughout the community, or has high academic significance.
+    * Metrics must be reported in the RFC (OSS usage, H5 index, etc.)
+* The addition is unlikely to have API changes as time progresses
+* The addition is well written / tested

--- a/sigs/addons/MIGRATION_TO_CORE.md
+++ b/sigs/addons/MIGRATION_TO_CORE.md
@@ -15,7 +15,8 @@ the move with a larger community audience.
     * Additions which only subclass Keras APIs should submit their migration proposals to 
     [Keras Governance](https://github.com/keras-team/governance)
     
-4. A sponsor from the TF/Keras team must agree to shepard the transition.
+4. A sponsor from the TF/Keras team must agree to shepard the transition and maintain 
+the new API in tensorflow/tensorflow.
    * If no sponsor is obtained after 45 days the RFC will be rejected and will remain 
    as part of Addons.
 5. If a sponsor is obtained, and the RFC is approved, a pull request must move the 

--- a/sigs/addons/MIGRATION_TO_CORE.md
+++ b/sigs/addons/MIGRATION_TO_CORE.md
@@ -26,7 +26,7 @@ if possible. If an alias is not possible (e.g. large parameter changes), then a 
 warning will be added and will be removed from TFA after 2 releases. 
 
 
-### Criteria for Migration
+### Criteria for Migration RFC
 * The addition is widely used throughout the community, or has high academic significance.
     * Metrics must be reported in the RFC (OSS usage, H5 index, etc.)
 * The addition is unlikely to have API changes as time progresses


### PR DESCRIPTION
Tried to incorporate the discussion points in #239 into documentation. Closes #239 once agreed upon.

The goal of this PR is to standardize how Addons components will be migrated going forward. After the RFC template and and Procedure are agreed upon we will submit the proposal for GELU migration.

cc @karmel @alextp @bhack  for feedback