### PR TITLE
RFC: Migrate gelu activation from Addons to Core

### DIFF
--- a/rfcs/20200525-gelu-migration.md
+++ b/rfcs/20200525-gelu-migration.md
@@ -1,0 +1,75 @@
+# Migrate gelu activation from TensorFlow Addons to TensorFlow Core
+
+| Status      | Proposed (Waiting for Sponsor)                                                                                           |
+| :---------- | :------------------------------------------------------------------------------------------------- |
+| **RFC #**   | TBD after PR |                                       |
+| **Authors** | Tzu-Wei Sung (@WindQAQ) & Sean Morgan (@seanpmorgan) |
+| **Sponsor** | TBD   |
+| **Updated** | 2020-05-XX |
+| **Sponsorship Deadline** | 2020-07-XX (45 Days after submission)  |
+
+## Rationale for Migration
+* [Gaussian Error Linear Units (GELUs)](https://arxiv.org/pdf/1606.08415.pdf) cited 600+ times
+* Used in BERT and other influential architectures
+* Multiple approvals from TF side: 
+    * https://github.com/tensorflow/tensorflow/pull/33945#issuecomment-617832325
+    * https://github.com/tensorflow/tensorflow/issues/32783#issuecomment-537284266
+
+## Historical Information
+* Have there been signifiant issues reported to Addons that need to be adressed?
+    * Only ABI incompatibilities for the custom-op (not an issue if built along with core TF)
+* When was it implemented in Addons?
+    * C++ custom-op added **2019-08-2019 (TFA 0.5.0)**
+    * Python composite op added **2020-02-26 (TFA 0.9.0)**
+* We have [performed benchmarking of the GELU activation](https://colab.research.google.com/drive/1rLb4EuydbFg9PbhboXhCDqopcl6BmphG#scrollTo=0GL2x2S4zxW3) 
+which shows there it may be beneficial to retain the custom-ops, but the maintence burden has grown 
+to much for us to continue to support it in Addons.
+* This migration is long over-due but we've struggled with finalizing the migration process.
+
+## Implementation Details
+* Link to implementation in Addons:
+    * Python: [https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/activations/gelu.py](https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/activations/gelu.py)
+    * C++ : [https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.h](https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.h) 
+* Does this include custom-op kernels?
+    * Yes, but currently proposing to just migrate the python composite op. This may 
+    change with discussion in the RFC.
+    * Are they CPU/GPU/TPU compatible?
+        * CPU/GPU compatible. No support for TPU.
+* What is the pytest coverage of the addon?
+    * `tensorflow_addons/activations/gelu.py 89%`
+## Changes to Implementation (If Needed)
+```
+def gelu(x: types.TensorLike, approximate: bool = True) -> tf.Tensor:
+    x = tf.convert_to_tensor(x)
+    if approximate:
+        pi = tf.cast(math.pi, x.dtype)
+        coeff = tf.cast(0.044715, x.dtype)
+        return 0.5 * x * (1.0 + tf.tanh(tf.sqrt(2.0 / pi) * (x + coeff * tf.pow(x, 3))))
+    else:
+        return 0.5 * x * (1.0 + tf.math.erf(x / tf.cast(tf.sqrt(2.0), x.dtype)))
+```
+The above implementation would only bring over the python composite op. Since there is 
+[no way for us to build tfxla kernels](https://github.com/tensorflow/tensorflow/pull/33945#issuecomment-617842977) 
+we had no support for TPUs in Addons.  [There were comments](https://github.com/tensorflow/tensorflow/pull/33945#issuecomment-625380208) 
+about using a "selector", but we would need guidance on how to implement that.
+
+We may also want to discuss the `approximate` bool and if it should be included in the 
+upstream version.
+
+
+## Transition Plan
+* The activation would land in [nn_ops.py](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow//python/ops/nn_ops.py) as well as in [keras advaced_activations](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow/python/keras/layers/advanced_activations.py)
+* No planned changes to the parameter signatures at this time
+* Addons would deprecate our activation and make a call to the core functionality.
+
+## Relevant GitHub Issues
+https://github.com/tensorflow/tensorflow/pull/33945
+https://github.com/tensorflow/addons/issues/550
+https://github.com/tensorflow/tensorflow/issues/32783
+
+## Questions and Discussion Topics
+* Whom from the TF core team would sponsor this migration and ownership of the API?
+* Is it worth brining over the custom-op kernels for CPU/GPU?
+
+## Final Decision
+TBD

--- a/rfcs/20200525-gelu-migration.md
+++ b/rfcs/20200525-gelu-migration.md
@@ -5,8 +5,8 @@
 | **RFC #**   | TBD after PR |                                       |
 | **Authors** | Tzu-Wei Sung (@WindQAQ) & Sean Morgan (@seanpmorgan) |
 | **Sponsor** | TBD   |
-| **Updated** | 2020-05-XX |
-| **Sponsorship Deadline** | 2020-07-XX (45 Days after submission)  |
+| **Updated** | 2020-06-02 |
+| **Sponsorship Deadline** | 2020-07-17 (45 Days after submission)  |
 
 ## Rationale for Migration
 * [Gaussian Error Linear Units (GELUs)](https://arxiv.org/pdf/1606.08415.pdf) cited 600+ times
@@ -58,7 +58,8 @@ upstream version.
 
 
 ## Transition Plan
-* The activation would land in [nn_ops.py](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow//python/ops/nn_ops.py) as well as in [keras advaced_activations](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow/python/keras/layers/advanced_activations.py)
+* The activation would land in [nn_ops.py](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow//python/ops/nn_ops.py), [keras activations](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow/python/keras/activations.py),
+ and possibly in [keras advaced_activation layers](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow/python/keras/layers/advanced_activations.py)
 * No planned changes to the parameter signatures at this time
 * Addons would deprecate our activation and make a call to the core functionality.
 * After merging to TF Core:

--- a/rfcs/20200525-gelu-migration.md
+++ b/rfcs/20200525-gelu-migration.md
@@ -2,7 +2,7 @@
 
 | Status      | Proposed (Waiting for Sponsor)                                                                                           |
 | :---------- | :------------------------------------------------------------------------------------------------- |
-| **RFC #**   | TBD after PR |                                       |
+| **RFC #**   | [252](https://github.com/tensorflow/community/pull/252) |                                       |
 | **Authors** | Tzu-Wei Sung (@WindQAQ) & Sean Morgan (@seanpmorgan) |
 | **Sponsor** | TBD   |
 | **Updated** | 2020-06-02 |

--- a/rfcs/20200525-gelu-migration.md
+++ b/rfcs/20200525-gelu-migration.md
@@ -1,11 +1,11 @@
 # Migrate gelu activation from TensorFlow Addons to TensorFlow Core
 
-| Status      | Proposed (Waiting for Sponsor)                                                                                           |
+| Status      | Accepted                                                                                          |
 | :---------- | :------------------------------------------------------------------------------------------------- |
 | **RFC #**   | [252](https://github.com/tensorflow/community/pull/252) |                                       |
 | **Authors** | Tzu-Wei Sung (@WindQAQ) & Sean Morgan (@seanpmorgan) |
-| **Sponsor** | TBD   |
-| **Updated** | 2020-06-02 |
+| **Sponsor** | @alextp   |
+| **Updated** | 2020-07-15 |
 | **Sponsorship Deadline** | 2020-07-17 (45 Days after submission)  |
 
 ## Rationale for Migration

--- a/rfcs/20200525-gelu-migration.md
+++ b/rfcs/20200525-gelu-migration.md
@@ -28,8 +28,8 @@ to much for us to continue to support it in Addons.
 
 ## Implementation Details
 * Link to implementation in Addons:
-    * Python: [https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/activations/gelu.py](https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/activations/gelu.py)
-    * C++ : [https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.h](https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.h) 
+    * Python: https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/activations/gelu.py
+    * C++ : https://github.com/tensorflow/addons/blob/r0.10/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.h
 * Does this include custom-op kernels?
     * Yes, but currently proposing to just migrate the python composite op. This may 
     change with discussion in the RFC.
@@ -61,13 +61,15 @@ upstream version.
 * The activation would land in [nn_ops.py](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow//python/ops/nn_ops.py) as well as in [keras advaced_activations](https://github.com/tensorflow/tensorflow/blob/r2.2/tensorflow/python/keras/layers/advanced_activations.py)
 * No planned changes to the parameter signatures at this time
 * Addons would deprecate our activation and make a call to the core functionality.
+* After merging to TF Core:
+    * Consolidate/remove https://github.com/tensorflow/models/blob/r2.2.0/official/modeling/activations/gelu.py
+    * Consolidate/remove https://github.com/tensorflow/models/blob/r2.2.0/official/modeling/activations/gelu_test.py
+    * Consolidate/remove https://github.com/tensorflow/models/blob/r2.2.0/official/nlp/xlnet/xlnet_modeling.py#L29
 
 ## Relevant GitHub Issues
-https://github.com/tensorflow/tensorflow/pull/33945
-
-https://github.com/tensorflow/addons/issues/550
-
-https://github.com/tensorflow/tensorflow/issues/32783
+* https://github.com/tensorflow/tensorflow/pull/33945
+* https://github.com/tensorflow/addons/issues/550
+* https://github.com/tensorflow/tensorflow/issues/32783
 
 ## Questions and Discussion Topics
 * Whom from the TF core team would sponsor this migration and ownership of the API?

--- a/rfcs/20200525-gelu-migration.md
+++ b/rfcs/20200525-gelu-migration.md
@@ -22,7 +22,7 @@
     * C++ custom-op added **2019-08-2019 (TFA 0.5.0)**
     * Python composite op added **2020-02-26 (TFA 0.9.0)**
 * We have [performed benchmarking of the GELU activation](https://colab.research.google.com/drive/1rLb4EuydbFg9PbhboXhCDqopcl6BmphG#scrollTo=0GL2x2S4zxW3) 
-which shows there it may be beneficial to retain the custom-ops, but the maintence burden has grown 
+which shows it may be beneficial to retain the custom-ops, but the maintence burden has grown 
 to much for us to continue to support it in Addons.
 * This migration is long over-due but we've struggled with finalizing the migration process.
 
@@ -69,7 +69,7 @@ https://github.com/tensorflow/tensorflow/issues/32783
 
 ## Questions and Discussion Topics
 * Whom from the TF core team would sponsor this migration and ownership of the API?
-* Is it worth brining over the custom-op kernels for CPU/GPU?
+* Is it worth bringing over the custom-op kernels for CPU/GPU?
 
 ## Final Decision
 TBD

--- a/rfcs/20200525-gelu-migration.md
+++ b/rfcs/20200525-gelu-migration.md
@@ -64,7 +64,9 @@ upstream version.
 
 ## Relevant GitHub Issues
 https://github.com/tensorflow/tensorflow/pull/33945
+
 https://github.com/tensorflow/addons/issues/550
+
 https://github.com/tensorflow/tensorflow/issues/32783
 
 ## Questions and Discussion Topics


### PR DESCRIPTION
Following the yet to be merged template from: https://github.com/tensorflow/community/pull/241

This is a bit overdue so wanted to start the discussion period. Linking PR:
https://github.com/tensorflow/tensorflow/pull/33945