### PR TITLE
Add a note about Python versions

### DIFF
--- a/governance/api-reviews.md
+++ b/governance/api-reviews.md
@@ -23,7 +23,7 @@ the comments to get an answer.
 
 TensorFlow supports a range of Python versions, and changes need to be
 compatible with all of them. This means that language features not available in
-TensorFlow's minimum supported version cannot be used. 
+any of TensorFlow's supported version cannot be used.
 
 We regularly reconsider the range of supported versions based on the number of
 affected users (estimated via pip downloads by Python version), and the default

--- a/governance/api-reviews.md
+++ b/governance/api-reviews.md
@@ -19,7 +19,20 @@ the comments to get an answer.
 
 ## High level points
 
+### Python Versions
+
+TensorFlow supports a range of Python versions, and changes need to be
+compatible with all of them. This means that language features not available in
+TensorFlow's minimum supported version cannot be used. 
+
+We regularly reconsider the range of supported versions based on the number of
+affected users (estimated via pip downloads by Python version), and the default
+installed version of Python on important platforms (Linux distributions, OSX,
+...), but these are large, breaking changes to the ecosystem which are not
+triggered by reviews of individual features.
+
 ### Backward and forward compatibility
+
 We avoid backwards-incompatible API changes. We also avoid
 backwards-incompatible behavior changes, such as restricting the set of valid
 inputs to a function or extending the set of valid outputs of a function. Adding

--- a/governance/api-reviews.md
+++ b/governance/api-reviews.md
@@ -23,7 +23,7 @@ the comments to get an answer.
 
 TensorFlow supports a range of Python versions and changes need to be
 compatible with all of them. This means that language features not available in
-any of TensorFlow's supported version cannot be used.
+any of [TensorFlow's supported versions](https://www.tensorflow.org/install) cannot be used.
 
 We regularly reconsider the range of supported versions based on the number of
 affected users (estimated via pip downloads by Python version), and the default

--- a/governance/api-reviews.md
+++ b/governance/api-reviews.md
@@ -21,7 +21,7 @@ the comments to get an answer.
 
 ### Python Versions
 
-TensorFlow supports a range of Python versions, and changes need to be
+TensorFlow supports a range of Python versions and changes need to be
 compatible with all of them. This means that language features not available in
 any of TensorFlow's supported version cannot be used.
 


### PR DESCRIPTION
Clarify how Python version compatibility is handled. This is mostly covered by testing, since we do run tests with the minimum version, but not entirely (as seen with 3.8 and async). 