### PR TITLE
Policy to require public types for API

### DIFF
--- a/governance/api-reviews.md
+++ b/governance/api-reviews.md
@@ -159,6 +159,10 @@ latter prevents the implementation from distinguishing between the caller not
 setting the argument vs. the caller setting the argument to the default value,
 which may be needed when the default behavior is changing.
 
+#### Documented types
+
+Arguments and return values to public APIs must be either be of public types, or inherit from a public type. This ensures that the arguments and return value types are documented and gives users clearer guidance on what can be passed to a public API, and what can they do with the returned values. If it is not desirable for the user to construct these types on their own, one can choose to expose superclass with no constructor, but adequate docstrings.
+
 ### Does it belong in TF at all?
 
 As TF evolves there’s a tendency to put everything inside of it, with costs

--- a/governance/api-reviews.md
+++ b/governance/api-reviews.md
@@ -161,7 +161,12 @@ which may be needed when the default behavior is changing.
 
 #### Documented types
 
-Arguments and return values to public APIs must be either be of public types, or inherit from a public type. This ensures that the arguments and return value types are documented and gives users clearer guidance on what can be passed to a public API, and what can they do with the returned values. If it is not desirable for the user to construct these types on their own, one can choose to expose superclass with no constructor, but adequate docstrings.
+Arguments and return values to public APIs must be either public types, or
+inherit from a public type. This ensures that the argument types and return 
+value types are documented and gives users clear guidance on what can be 
+passed to a public API, and what can they do with the returned values. 
+If it is not desirable for the user to construct these types on their own, 
+one can choose to expose superclass with no constructor, but adequate docstrings.
 
 ### Does it belong in TF at all?
 


### PR DESCRIPTION
We want to require all new public APIs to have publicly documented arguments and return values.