### PR TITLE
RFC: Creating SIG Models

### DIFF
--- a/rfcs/20201023-sig-models.md
+++ b/rfcs/20201023-sig-models.md
@@ -1,0 +1,91 @@
+# Creating SIG Models
+
+| Status        | Proposed                                             |
+:-------------- |:---------------------------------------------------- |
+| **RFC #**     |                                                      |
+| **Author(s)** | Jaeyoun Kim (jaeyounkim@google.com), Jing Li (jingli@google.com), Mike Liang (mliang@google.com), Shuangfeng Li (shuangfeng@google.com) |
+| **Sponsor**   | Thea Lamkin (thealamkin@google.com)                  |
+| **Updated**   | 2020-10-23                                           |
+
+## What is this group for?
+
+This group is for discussions and collaborations on enabling community
+contributions to [TensorFlow Model Garden](https://github.com/tensorflow/models)
+and [Tensorflow Hub](https://github.com/tensorflow/hub).
+
+SIG Models will focus on empowering the community to contribute state-of-the-art
+model implementation in TensorFlow 2. It will benefit the whole community by
+providing recommended implementations and models with reproducible results.
+
+SIG Models will have several subgroups (e.g., SIG Models Vision and SIG Models
+NLP) covering different machine learning areas. There are several SIG leads for
+each group to coordinate the contributions, run community events like contests,
+and maintain the code quality through the review process. Each group has the
+flexibility to operate differently.
+
+SIG is also a place for community discussions and sharing best practices of
+using TensorFlow 2 for state-of-the-art research. Furthermore, SIG provides
+product feedback to help TensorFlow to be improved.
+
+## Who will be part of it?
+
+SIG Models are open, membership will be entirely public, and anybody interested
+in model contributions or participating in the discussion can join the SIG.
+There can be different ways to participate:
+
+* Everyone in the community can pick GitHub model tasks and contribute models.
+* They can also join the regular SIG meetings or email groups to participate in
+  the discussions. To participate, request an invitation to join the SIG mailing
+  list. Archives of the mailing list are publicly accessible.
+
+We will identify SIG leads from the community to run the SIG Models groups.
+Initially, we plan to set up the SIG Models Vision group:
+
+* SIG Models Vision leads
+  * George Thiruvathukal, gkt@cs.luc.edu (Loyola University Chicago)
+  * Yung-Hsiang Lu, yunglu@purdue.edu (Purdue University)
+* Co-leads and sponsors from TensorFlow
+  * Jaeyoun Kim, jaeyounkim@google.com (TensorFlow Model Garden)
+  * Jing Li, jingli@google.com (TensorFlow Model Garden)
+  * Mike Liang, mliang@google.com (TensorFlow Hub)
+  * Shuangfeng Li, shuangfeng@google.com (TensorFlow Lite)
+
+## What initial problems will the group tackle?
+
+We will start with the SIG Models Vision group. Initially, the group leads will
+run a contest to motivate the community to contribute state-of-the-art computer
+vision models using TensorFlow 2. 
+
+For example:
+
+* Define/release model implementation tasks, rules, and evaluation criteria for
+  the contest
+* Review initial submissions and provide more support for selected high-quality
+  submissions
+* Review final submissions and announce results
+
+## What modes of communication do you intend to use?
+
+We plan to have a mailing list
+([models@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/models)),
+arrange a regular (e.g., monthly) video conference call rotated by the SIG
+leads. We will also use a Gitter chat channel
+(https://gitter.im/tensorflow/models) for discussions.
+
+As we have multiple SIG subgroups, each subgroup may run meetings and events
+using different modes of communication.
+
+## Launch plan
+
+* Video conference calls with initial interested parties to finalize the charter
+* SIG set up with initial group members
+* SIG added to community pages on tensorflow.org
+* SIG leads and sponsors start discussions about initial work items
+* Write a blog post about the SIG Models with the initial achievements and
+  welcome more members
+
+## Code of Conduct
+
+As with all forums and spaces related to TensorFlow, SIG Models is subject to
+the [TensorFlow Code of
+Conduct](https://github.com/tensorflow/tensorflow/blob/master/CODE_OF_CONDUCT.md).

--- a/rfcs/20201023-sig-models.md
+++ b/rfcs/20201023-sig-models.md
@@ -2,10 +2,10 @@
 
 | Status        | Proposed                                             |
 :-------------- |:---------------------------------------------------- |
-| **RFC #**     |                                                      |
+| **RFC #**     | 314                                                  |
 | **Author(s)** | Jaeyoun Kim (jaeyounkim@google.com), Jing Li (jingli@google.com), Mike Liang (mliang@google.com), Shuangfeng Li (shuangfeng@google.com) |
 | **Sponsor**   | Thea Lamkin (thealamkin@google.com)                  |
-| **Updated**   | 2020-10-23                                           |
+| **Updated**   | 2020-10-30                                           |
 
 ## What is this group for?
 
@@ -23,8 +23,8 @@ each group to coordinate the contributions, run community events like contests,
 and maintain the code quality through the review process. Each group has the
 flexibility to operate differently.
 
-SIG is also a place for community discussions and sharing best practices of
-using TensorFlow 2 for state-of-the-art research. Furthermore, SIG provides
+SIG Models is also a place for community discussions and sharing best practices of
+using TensorFlow 2 for state-of-the-art research. Furthermore, SIG Models provides
 product feedback to help TensorFlow to be improved.
 
 ## Who will be part of it?
@@ -70,7 +70,7 @@ We plan to have a mailing list
 ([models@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/models)),
 arrange a regular (e.g., monthly) video conference call rotated by the SIG
 leads. We will also use a Gitter chat channel
-(https://gitter.im/tensorflow/models) for discussions.
+(https://gitter.im/tensorflow/sig-models) for discussions.
 
 As we have multiple SIG subgroups, each subgroup may run meetings and events
 using different modes of communication.


### PR DESCRIPTION
This RFC will be open for comment until Wednesday, November 11st, 2020.

# Creating SIG Models

We propose to create a TensorFlow SIG Models.

| Status        | Proposed                                             |
:-------------- |:---------------------------------------------------- |
| **RFC #**     |           314                                           |
| **Author(s)** | Jaeyoun Kim (jaeyounkim@google.com), Jing Li (jingli@google.com), Mike Liang (mliang@google.com), Shuangfeng Li (shuangfeng@google.com) |
| **Sponsor**   | Thea Lamkin (thealamkin@google.com)                  |
| **Updated**   | 2020-10-23                                           |

## What is this group for?

This group is for discussions and collaborations on enabling community
contributions to [TensorFlow Model Garden](https://github.com/tensorflow/models)
and [Tensorflow Hub](https://github.com/tensorflow/hub).

SIG Models will focus on empowering the community to contribute state-of-the-art
model implementation in TensorFlow 2. It will benefit the whole community by
providing recommended implementations and models with reproducible results.

SIG Models will have several subgroups (e.g., SIG Models Vision and SIG Models
NLP) covering different machine learning areas. There are several SIG leads for
each group to coordinate the contributions, run community events like contests,
and maintain the code quality through the review process.
