### PR TITLE
Mark TFRT Kernel Fallback doc as obsolete

### DIFF
--- a/rfcs/20200712-tfrt-kernel-fallback.md
+++ b/rfcs/20200712-tfrt-kernel-fallback.md
@@ -1,6 +1,6 @@
 # TFRT Kernel Fallback
 
-| Status        | Accepted                                               |
+| Status        | Obsolete                                                |
 | :------------ | :------------------------------------------------------ |
 | **RFC #**     | [266](https://github.com/tensorflow/community/pull/266) |
 | **Author(s)** | Anna Revinskaya (annarev@google.com), Jeremy Lau (lauj@google.com) |


### PR DESCRIPTION
The project scope was determined to be larger than originally anticipated. The doc as written proposes to support only a subset of ops. However, we would need to support all ops instead including resources, datasets etc. for it to provide substantial utility. The new scope would not be feasible within the original timeline.

Also, I switched team and wouldn't be able to work on it.