### PR TITLE
Update tf.js SIG members

### DIFF
--- a/sigs/tf.js/CHARTER.md
+++ b/sigs/tf.js/CHARTER.md
@@ -98,3 +98,4 @@ new, community-owned repos that the SIG will drive.
 - Va Barbosa (IBM)
 - YiHong Wang (IBM)
 - Zebai (Alibaba)
+- Belem Zhang (Intel)


### PR DESCRIPTION
Add Belem Zhang from Intel into the SIG members.

Belem is focusing on the Web-based ML benchmarking and performance and would like to join the tf.js SIG members.

@sandeepngupta @pyu10055, PTAL. Thanks!