### PR TITLE
Update contacts in TensorBoard community charter.

### DIFF
--- a/sigs/tensorboard/CHARTER.md
+++ b/sigs/tensorboard/CHARTER.md
@@ -20,7 +20,8 @@ Archives of the mailing list will be publicly accessible.
 ## Contacts
 * Project leads: 
     * Mani Varadarajan [@maniv](https://github.com/manivaradarajan) - maniv at google
-    * Gal Oshri [@GalOshri](https://github.com/GalOshri) - goshri at google
+    * Nick Felt [@nfelt](https://github.com/nfelt) - nickfelt at google
+    * Stan Bileschi [@bileschi](https://github.com/bileschi) - bileschi at google
 * For administrative questions, contact Edd Wilder-James [@ewilderj](https://github.com/ewilderj) - ewj at google
 
 ## Code of Conduct


### PR DESCRIPTION
Gal is no longer part of the TensorBoard project at Google