### PR TITLE
Add a standard README.md template

### DIFF
--- a/governance/SIG-readme-template.md
+++ b/governance/SIG-readme-template.md
@@ -1,0 +1,47 @@
+
+# :framed_picture [SIG Logo](https://github.com/tensorflow/community/tree/master/sigs/logos)
+
+## SIG presentation
+A general short description of the Repository/SIG.
+
+## Badges section
+Add badges for you repostiroy (pypy, python, gitter, api etc.) 
+
+CI/Buid specifc badges
+
+## Project/Repository structure
+A repository overiew with a short description of its tree/modularity
+
+## Tensorflow compatibility Matrix
+Repository releases compatibility with TF and Python version or (other languages, cuda, etc.)
+
+## Release policy
+Describe the release policy:
+
+E.g. A release each Tensorflow release, multiple releases between two Tensorflow releases, etc.
+
+## Installation
+Quick instruction on how to install the packaged version of the repository
+
+## Docker
+How to start to use the library inside a Docker container.
+If the specific repo doesn't maintain its own Docker image we could route the user to install the package inside the Tensorflow official Docker container
+
+## Build from source
+Pointer to a specific CONTRIBUTING.md section
+
+## Example
+A very minimal inline primer just to quiclky expose the library
+
+## DOCS/API
+Link to the Tensorflow web site
+
+## Contributing
+Link to the CONTRIBUTING.md
+
+## Support/community
+Mailing list/Forum
+Gitter
+
+## Extra info
+Pleae add any extra info or references to others Markdown files in the specific repo

--- a/governance/SIG-readme-template.md
+++ b/governance/SIG-readme-template.md
@@ -4,16 +4,21 @@
 ## SIG presentation
 A general short description of the Repository/SIG.
 
+## Example
+A very minimal inline primer just to quiclky expose the library
+
+## DOCS/API
+Link to the Tensorflow web site
+
 ## Badges section
 Add badges for you repostiroy (pypy, python, gitter, api etc.) 
-
 CI/Buid specifc badges
-
-## Project/Repository structure
-A repository overiew with a short description of its tree/modularity
 
 ## Tensorflow compatibility Matrix
 Repository releases compatibility with TF and Python version or (other languages, cuda, etc.)
+
+## Project/Repository structure
+A repository overiew with a short description of its tree/modularity
 
 ## Release policy
 Describe the release policy:
@@ -29,12 +34,6 @@ If the specific repo doesn't maintain its own Docker image we could route the us
 
 ## Build from source
 Pointer to a specific CONTRIBUTING.md section
-
-## Example
-A very minimal inline primer just to quiclky expose the library
-
-## DOCS/API
-Link to the Tensorflow web site
 
 ## Contributing
 Link to the CONTRIBUTING.md

--- a/governance/SIG-readme-template.md
+++ b/governance/SIG-readme-template.md
@@ -1,21 +1,21 @@
 
 # :framed_picture: [SIG Logo](https://github.com/tensorflow/community/tree/master/sigs/logos)
 
-## SIG presentation
-A general short description of the Repository/SIG.
+## SIG description
+A short overview of the SIG goals & scope.
 
 ## Example
-A very minimal inline primer just to quiclky expose the library
+A minimal inline primer to quickly expose the library
 
-## DOCS/API
-Link to the Tensorflow web site
+## Docs/API
+Link to the appropriate Tensorflow web site page (if applicable)
 
-## Badges section
-Add badges for you repostiroy (pypy, python, gitter, api etc.) 
-CI/Buid specifc badges
+## Badges
+Add badges for you repository (pypy, python, gitter, api etc.) 
+CI/Buid specific badges
 
-## Tensorflow compatibility Matrix
-Repository releases compatibility with TF and Python version or (other languages, cuda, etc.)
+## TensorFlow compatibility Matrix
+Releases compatibility with TF and Python versions or (other languages, cuda, etc.)
 
 ## Project/Repository structure
 A repository overiew with a short description of its tree/modularity
@@ -23,14 +23,14 @@ A repository overiew with a short description of its tree/modularity
 ## Release policy
 Describe the release policy:
 
-E.g. A release each Tensorflow release, multiple releases between two Tensorflow releases, etc.
+E.g. A release for each Tensorflow release, multiple releases between two Tensorflow releases, etc.
 
 ## Installation
 Quick instruction on how to install the packaged version of the repository
 
 ## Docker
-How to start to use the library inside a Docker container.
-If the specific repo doesn't maintain its own Docker image we could route the user to install the package inside the Tensorflow official Docker container
+How to use the library inside a Docker container.
+If the specific repo doesn't maintain its own Docker image, consider directing users to install the package inside the Tensorflow official Docker container.
 
 ## Build from source
 Pointer to a specific CONTRIBUTING.md section
@@ -38,9 +38,9 @@ Pointer to a specific CONTRIBUTING.md section
 ## Contributing
 Link to the CONTRIBUTING.md
 
-## Support/community
+## Support/Community
 Mailing list/Forum
 Gitter
 
 ## Extra info
-Pleae add any extra info or references to others Markdown files in the specific repo
+Please add any extra info or references to important Markdown files or resources in the repo

--- a/governance/SIG-readme-template.md
+++ b/governance/SIG-readme-template.md
@@ -1,5 +1,5 @@
 
-# :framed_picture [SIG Logo](https://github.com/tensorflow/community/tree/master/sigs/logos)
+# :framed_picture: [SIG Logo](https://github.com/tensorflow/community/tree/master/sigs/logos)
 
 ## SIG presentation
 A general short description of the Repository/SIG.


### PR DESCRIPTION
This is a Draft `README.md` template. 
It is part of an effort to standardize some early access info for [Github community health files](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) across the TensorFlow ecosystem repositories.