### PR TITLE
Add CONTRIBUTING.md template

### DIFF
--- a/governance/SIG-contributing-template.md
+++ b/governance/SIG-contributing-template.md
@@ -1,0 +1,50 @@
+## We welcome contribution
+Describe what kind of issues a new contributor could pick.
+
+[TODO:] A list of standardized labels “good first issue”?, “contribution welcome”?, etc.
+
+## Contributor checklist
+* Comment on an existing ticket or open a new one before coding any PR
+* Wait for a specific approval reply from mantainers and an `approved-for-PR` label
+* Read and Sign the CLA
+* Follow Tensorflow coding style
+* Follow extra repository specific code style
+* Write and execute tests
+* Lint your code
+
+## Environment setup
+How to checkout the code and mount the volume inside a container
+
+
+## Build from source
+How to build the code from source inside a container
+
+## Codestyle 
+Link to Google style guides and any other specific code style
+Linting info and how to configure pre-commit hooks
+
+## IDE
+Any available info for working with specific IDE
+How to use [Codespaces/Devcontainers](https://github.com/microsoft/vscode-dev-containers) if supported
+
+## DOCS
+To contribute to the documentation please follow [DOCS.md]
+
+## TESTS
+How to write and execute tests (bazel, pytest, etc.) or a link to a specific [TEST.md]
+
+## DEBUG
+How to debug your code
+
+## CI
+Quickly describe your CI
+
+## CODEOWNERS
+Describe how codeownership and maintainership in the repo:
+* How to be a Codeowner
+* How to be a Maintainer
+* MIA (Missing in Action) handling
+* Orphaned modules/features handling
+
+## Extra info
+Pleae add any extra info or references to others Markdown files in the specific repo


### PR DESCRIPTION
This is a Draft CONTRIBUTING.md template.
It is part of an effort to standardize some early access info for [Github community health files](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) across the TensorFlow ecosystem repositories.