### PR TITLE
RFC: [determinism] Add tf.nn.depthwise_conv2d to op list in

### DIFF
--- a/rfcs/20210119-determinism.md
+++ b/rfcs/20210119-determinism.md
@@ -114,6 +114,7 @@ As part of the implementation, we will review all ops to make a determination of
 * `tf.math.unsorted_segment_sqrt_n` forward
 * `tf.math.unsorted_segment_prod` forward
 * `tf.math.unsorted_segment_sum` forward
+* `tf.nn.depthwise_conv2d` gradient w.r.t `filter`
 * `tf.nn.softmax_cross_entropy_with_logits` forward
 * `tf.nn.sparse_softmax_cross_entropy_with_logits` forward
 * `tf.sparse.sparse_dense_matmul` forward


### PR DESCRIPTION
Following the results of [this study](https://gist.github.com/duncanriach/4c18cb07a73510c5fcb2deb52adbffaa), this PR adds tf.nn.depthwise_conv2d to the list of ops for which `tf.errors.UnimplementedError` will be thrown.

cc @sanjoy.