### PR TITLE
RFC: Create SIG Federated 

### DIFF
--- a/rfcs/20220719-sig-federated
+++ b/rfcs/20220719-sig-federated
@@ -1,0 +1,89 @@
+
+# RFC: Establish SIG Federated
+
+| Status        | Proposed     |
+:-------------- |:---------------------------------------------------- |
+| **RFC #**     | tbd |
+| **Author(s)** | Krzysztof Ostrowski (ostrowski@google.com|
+| **Sponsor**   | Thea Lamkin (thealamkin@google.com)            |
+| **Updated**   | 2022-07-19                                           |
+
+# SIG Federated Proposed Charter
+
+## Objective
+
+[TensorFlow Federated (TFF)](http://tensorflow.org/federated) is an OSS platform based on TensorFlow for machine learning and other computations on decentralized data. TFF is [hosted on GitHub](https://github.com/tensorflow/federated) and available to OSS and industry contributors and potential [platform collaborators](https://github.com/tensorflow/federated/tree/main/docs/collaborations).
+
+We would like to build and cultivate a center of gravity around TFF, where partners from outside Google can contribute to growing the TFF platform and the surrounding ecosystem, and help us grow use of TFF and [Federated Learning](https://ai.googleblog.com/2017/04/federated-learning-collaborative.html) in the industry.
+
+SIG Federated will focus on jointly evolving TFF as a platform and ecosystem by Google and a small number of committed platform partners.
+
+We will capture here conversations about creation of new workstreams, project scoping, planning, logistics, and design, new product and development roadmaps jointly developed with partners, and discussions about components maintained by community contributors.
+
+These conversations will be open to and publicly accessible by all interested parties at a SIG discussion forum hosted at [discuss.tensorflow.org](https://discuss.tensorflow.org/c/special-interest-groups).
+
+### Goals
+
+*   Open up the TFF platform to collaborations with industry and OSS community partners
+*   Develop within the TFF ecosystem new features, platforms, and products to support all flavors of Federated Learning (FL) deployments, including cross-silo and cross-device FL
+*   Promote industry uses of FL and associated technologies, and normalize the FL-based approach to privacy through TFF
+*   Exploit complementary capabilities and synergies between TFF and other FL platforms, and develop mechanisms for interoperability
+*   Bootstrap joint development of shared FL standards, APIs, and best practices in TFF
+
+## Membership
+
+Everyone involved in developing or integrating with TensorFlow Federated (TFF) is welcome to participate in discussions. To participate, request an invitation to [the SIG Federated forum on discuss.tensorflow.org], and email tff-hello at google dot com to introduce yourself and tell us a few words about how you would like to contribute to the TFF ecosystem.
+
+The following organizations have agreed to participate in discussions and provide resources allowing the SIG to reach its goals:
+
+*   LinkedIn
+
+Other SIG members will be added via PR to [this document in GitHub]. Members are expected to regularly attend meetings, participate in technical discussions, and make regular technical contributions to the project.
+
+### Communication
+
+SIG Federated will hold at minimum monthly virtual meetings for roadmap sharing, design discussion, and SIG coordination. Agendas will be open to contribution and shared in advance. Meeting minutes will be shared on [the SIG Federated forum on discuss.tensorflow.org].
+
+Asynchronous communications will happen in the SIG discussion forum on tensorflow.org, including design proposals and roadmap update announcements.
+
+## Collaboration & Governance
+
+SIG Federated will be launched under the [TensorFlow governance umbrella](https://www.tensorflow.org/community/contribute), and leverage existing TensorFlow community infrastructure to more efficiently bootstrap collaboration.
+
+### Code
+
+Code contributions will be hosted under [the existing TensorFlow Federated (TFF) project](https://github.com/tensorflow/federated) on GitHub, under the Apache 2.0 license, governed by [TensorFlow’s collaboration rules](https://github.com/tensorflow/community/blob/master/governance/code-and-collaboration.md) and contributed under the Google CLA. The maintainers will be the existing maintainers of TFF for the platform as a whole. Additionally, members of the SIG will maintain parts of TFF they own.
+
+### Design Reviews & Roadmap
+
+Once launched, SIG Federated will immediately begin technical design conversations with publicly available archives. All significant design proposals and reviews will use a lightweight process to be established by the SIG, except for changes that are significant at the TensorFlow level, where we will follow the established RFC process.
+
+### Technical Governance
+
+A priority of the SIG will be to create collaboration workstreams within TFF, and establish a path for community members to develop ownership of these workstreams. Google engineers will continue to be responsible for the technical leadership of the TFF platform as a whole.
+
+## Timeline
+
+We propose the following basic timeline for accomplishing SIG goals.
+
+*   July 2022 - SIG Launch
+*   July 2022 - SIG Community Infrastructure (meetings, mailing list, etc) established
+*   July 2022 - SIG discussions begin
+
+## Contacts
+
+*   For technical questions, contact [Krzysztof Ostrowski](https://github.com/krzys-ostrowski) - ostrowski at google
+*   For administrative questions, contact [Thea Lamkin](https://github.com/theadactyl)) - thealamkin at google or [Joana Carrasqueira](https://github.com/joanafilipa) -joanafilipa at google
+
+## Resources
+
+*   [tensorflow.org/federated](http://tensorflow.org/federated) (project website)
+*   [tensorflow/federated @ Github](https://github.com/tensorflow/federated) (repo)
+*   [TFF Discord Server](https://discord.com/invite/5shux83qZ5) (contributors chat)
+*   Discussion forum TBD
+*   Community directory TBC
+*   Community meetings TBC
+
+## Code of Conduct
+
+SIG Federated is subject to the [TensorFlow Code of Conduct](https://github.com/tensorflow/tensorflow/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
# RFC: Establish SIG Federated

| Status        | Proposed     |
:-------------- |:---------------------------------------------------- |
| **RFC #**     | 423 |
| **Author(s)** | Krzysztof Ostrowski (ostrowski@google.com|
| **Sponsor**   | Thea Lamkin (thealamkin@google.com)            |
| **Updated**   | 2022-07-19                                           |

# Objective

[TensorFlow Federated (TFF)](http://tensorflow.org/federated) is an OSS platform based on TensorFlow for machine learning and other computations on decentralized data. TFF is [hosted on GitHub](https://github.com/tensorflow/federated) and available to OSS and industry contributors and potential [platform collaborators](https://github.com/tensorflow/federated/tree/main/docs/collaborations).

We would like to build and cultivate a center of gravity around TFF, where partners from outside Google can contribute to growing the TFF platform and the surrounding ecosystem, and help us grow use of TFF and [Federated Learning](https://ai.googleblog.com/2017/04/federated-learning-collaborative.html) in the industry.

SIG Federated will focus on jointly evolving TFF as a platform and ecosystem by Google and a small number of committed platform partners.